### PR TITLE
Change the computation in the extender, and fix #33

### DIFF
--- a/crates/math/benches/ntt.rs
+++ b/crates/math/benches/ntt.rs
@@ -1,16 +1,6 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use math::zq::{ntt::NttOperator, Modulus};
-use rand::RngCore;
-use std::{rc::Rc, vec};
-
-fn random_vector(size: usize, p: u64) -> Vec<u64> {
-	let mut rng = rand::thread_rng();
-	let mut v = vec![];
-	for _ in 0..size {
-		v.push(rng.next_u64() % p)
-	}
-	v
-}
+use std::rc::Rc;
 
 pub fn ntt_benchmark(c: &mut Criterion) {
 	let mut group = c.benchmark_group("ntt");
@@ -19,8 +9,8 @@ pub fn ntt_benchmark(c: &mut Criterion) {
 	let p = 4611686018326724609;
 
 	for vector_size in [1024usize, 4096].iter() {
-		let mut a = random_vector(*vector_size, p);
 		let q = Modulus::new(p).unwrap();
+		let mut a = q.random_vec(*vector_size);
 		let op = NttOperator::new(&Rc::new(q), *vector_size).unwrap();
 
 		group.bench_function(BenchmarkId::new("forward", vector_size), |b| {

--- a/crates/math/benches/rns.rs
+++ b/crates/math/benches/rns.rs
@@ -1,6 +1,5 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use math::rns::{RnsContext, RnsConverter, RnsScaler};
-use ndarray::ArrayView1;
 use num_bigint::BigUint;
 use rand::{thread_rng, RngCore};
 
@@ -35,15 +34,17 @@ pub fn rns_benchmark(c: &mut Criterion) {
 		&BigUint::from(46116860181065u64),
 	);
 
+	let mut y = vec![0; p.len()];
 	group.bench_function(
 		BenchmarkId::new("converter", format!("{}->{}", q.len(), p.len())),
 		|b| {
-			b.iter(|| converter.convert(&ArrayView1::from(&x)));
+			b.iter(|| converter.convert(&(&x).into(), &mut (&mut y).into()));
 		},
 	);
 
+	let mut y = x.clone();
 	group.bench_function(BenchmarkId::new("scaler", q.len()), |b| {
-		b.iter(|| scaler.scale(&x, x.len(), true));
+		b.iter(|| scaler.scale(&(&x).into(), &mut (&mut y).into(), true));
 	});
 
 	group.finish();

--- a/crates/math/src/rns/converter.rs
+++ b/crates/math/src/rns/converter.rs
@@ -6,7 +6,7 @@
 use super::RnsContext;
 use crate::{u256::U256, zq::Modulus};
 use itertools::izip;
-use ndarray::ArrayView1;
+use ndarray::{ArrayView1, ArrayViewMut1};
 use num_bigint::BigUint;
 use num_traits::ToPrimitive;
 
@@ -15,8 +15,8 @@ use num_traits::ToPrimitive;
 pub struct RnsConverter {
 	from: RnsContext, // Moduli q
 	to: RnsContext,   // Moduli p
-	q_star_mod_p: Vec<Vec<u64>>,
-	q_star_mod_p_shoup: Vec<Vec<u64>>,
+	garner_mod_p: Vec<Vec<u64>>,
+	garner_mod_p_shoup: Vec<Vec<u64>>,
 	theta_lo: Vec<u64>,
 	theta_hi: Vec<u64>,
 	q_mod_p: Vec<u64>,
@@ -35,23 +35,23 @@ impl RnsConverter {
 		izip!(&q_mod_p, &to.moduli_u64)
 			.for_each(|(qi, p)| q_mod_p_shoup.push(Modulus::new(*p).unwrap().shoup(*qi)));
 
-		// Store the q_star from `from` modulo the moduli of `to`.
-		let mut q_star_mod_p = Vec::with_capacity(to.moduli_u64.len());
-		let mut q_star_mod_p_shoup = Vec::with_capacity(to.moduli_u64.len());
+		// Store the garner from `from` modulo the moduli of `to`.
+		let mut garner_mod_p = Vec::with_capacity(to.moduli_u64.len());
+		let mut garner_mod_p_shoup = Vec::with_capacity(to.moduli_u64.len());
 		for p in &to.moduli_u64 {
-			let mut q_star_mod_p_i = Vec::with_capacity(from.moduli_u64.len());
-			from.q_star
+			let mut garner_mod_p_i = Vec::with_capacity(from.moduli_u64.len());
+			from.garner
 				.iter()
-				.for_each(|q_star| q_star_mod_p_i.push((q_star % *p).to_u64().unwrap()));
-			q_star_mod_p_shoup.push(Modulus::new(*p).unwrap().shoup_vec(&q_star_mod_p_i));
-			q_star_mod_p.push(q_star_mod_p_i);
+				.for_each(|garner| garner_mod_p_i.push((garner % *p).to_u64().unwrap()));
+			garner_mod_p_shoup.push(Modulus::new(*p).unwrap().shoup_vec(&garner_mod_p_i));
+			garner_mod_p.push(garner_mod_p_i);
 		}
 
-		// Define theta = floor(2^128 / q_i) = theta_lo + 2^64 * theta_hi.
+		// Define theta = ceil(2^127 * qtilde_i / q_i) = theta_lo + 2^64 * theta_hi.
 		let mut theta_lo = Vec::with_capacity(from.moduli_u64.len());
 		let mut theta_hi = Vec::with_capacity(from.moduli_u64.len());
-		for q in &from.moduli_u64 {
-			let mut theta_lo_i: BigUint = (BigUint::from(1u64) << 128) / *q;
+		for (q, qt) in izip!(&from.moduli_u64, &from.q_tilde) {
+			let mut theta_lo_i: BigUint = ((BigUint::from(*qt) << 127) + (*q >> 1)) / *q;
 			let theta_hi_i: BigUint = &theta_lo_i >> 64;
 			theta_lo_i -= &theta_hi_i << 64;
 			theta_lo.push(theta_lo_i.to_u64().unwrap());
@@ -61,8 +61,8 @@ impl RnsConverter {
 		Self {
 			from: from.clone(),
 			to: to.clone(),
-			q_star_mod_p,
-			q_star_mod_p_shoup,
+			garner_mod_p,
+			garner_mod_p_shoup,
 			theta_lo,
 			theta_hi,
 			q_mod_p,
@@ -70,62 +70,76 @@ impl RnsConverter {
 		}
 	}
 
+	/// Converts  a RNS representation in context `from` and returns a representation in context `to`.
+	///
+	/// Aborts if the number of rests is different than the number of moduli in debug mode.
+	pub fn convert_new(&self, rests_from: &ArrayView1<u64>) -> Vec<u64> {
+		let mut rests_to = vec![0; self.to.moduli.len()];
+		self.convert(rests_from, &mut (&mut rests_to).into());
+		rests_to
+	}
+
 	/// Convert a RNS representation in context `from` into a representation in context `to`.
 	///
 	/// Aborts if the number of rests is different than the number of moduli in debug mode.
-	pub fn convert(&self, rests_from: &ArrayView1<u64>) -> Vec<u64> {
+	pub fn convert(&self, rests_from: &ArrayView1<u64>, rests_to: &mut ArrayViewMut1<u64>) {
 		debug_assert_eq!(rests_from.len(), self.from.moduli_u64.len());
 
-		let mut rests_to = Vec::with_capacity(self.to.moduli_u64.len());
-
-		let mut y = Vec::with_capacity(rests_from.len());
 		let mut sum = U256::zero();
-		for (rests_from_i, theta_lo, theta_hi, q_tilde, q_tilde_shoup, qi) in izip!(
-			rests_from,
-			&self.theta_lo,
-			&self.theta_hi,
-			&self.from.q_tilde,
-			&self.from.q_tilde_shoup,
-			&self.from.moduli,
-		) {
-			let yi = qi.mul_shoup(*rests_from_i, *q_tilde, *q_tilde_shoup);
-			y.push(yi);
-			// Compute yi * theta
-			let lo = (*theta_lo as u128) * (yi as u128);
-			let hi = (*theta_hi as u128) * (yi as u128) + (lo >> 64);
-			sum.overflowing_add(U256::from([lo as u64, hi as u64, (hi >> 64) as u64, 0]));
+		for (rests_from_i, theta_lo, theta_hi) in izip!(rests_from, &self.theta_lo, &self.theta_hi,)
+		{
+			// Compute rests_from_i * theta
+			let lo = (*rests_from_i as u128) * (*theta_lo as u128);
+			let mi = (*rests_from_i as u128) * (*theta_hi as u128) + (lo >> 64);
+			let hi = mi >> 64;
+			sum.overflowing_add(U256::from([lo as u64, mi as u64, hi as u64, 0]));
 		}
-		sum >>= 128;
-		let value2 = sum.as_u64();
+		sum >>= 126;
+		let value = sum.as_u128();
+		let value = (value & 1) + (value >> 1);
 
-		for (q_star_mod_p_j, q_star_mod_p_shoup_j, p_j, q_mod_p_j, q_mod_p_shoup_j) in izip!(
-			&self.q_star_mod_p,
-			&self.q_star_mod_p_shoup,
+		for (to, garner_mod_p_j, garner_mod_p_shoup_j, p_j, q_mod_p_j, q_mod_p_shoup_j) in izip!(
+			rests_to.iter_mut(),
+			&self.garner_mod_p,
+			&self.garner_mod_p_shoup,
 			&self.to.moduli,
 			&self.q_mod_p,
 			&self.q_mod_p_shoup,
 		) {
 			let mut x = (2 * p_j.modulus()
-				- p_j.lazy_mul_shoup(value2, *q_mod_p_j, *q_mod_p_shoup_j)) as u128;
-			izip!(&y, q_star_mod_p_j, q_star_mod_p_shoup_j).for_each(
-				|(yi, q_star_mod_p_j_i, q_star_mod_p_shoup_j_i)| {
-					x += p_j.lazy_mul_shoup(*yi, *q_star_mod_p_j_i, *q_star_mod_p_shoup_j_i) as u128
-				},
-			);
-			rests_to.push(p_j.reduce_u128(x));
+				- p_j.lazy_mul_shoup(p_j.reduce_u128(value), *q_mod_p_j, *q_mod_p_shoup_j))
+				as u128;
+			for (rests_from_i, garner_mod_p_j_i, garner_mod_p_shoup_j_i) in
+				izip!(rests_from, garner_mod_p_j, garner_mod_p_shoup_j)
+			{
+				x += p_j.lazy_mul_shoup(*rests_from_i, *garner_mod_p_j_i, *garner_mod_p_shoup_j_i)
+					as u128
+			}
+			*to = p_j.reduce_u128(x);
 		}
-
-		rests_to
 	}
 }
 
 #[cfg(test)]
 mod tests {
+	use std::vec;
+
 	use super::RnsConverter;
 	use crate::rns::RnsContext;
-	use ndarray::ArrayView1;
-	use num_bigint::BigUint;
 	use rand::{thread_rng, RngCore};
+
+	static Q: &[u64; 3] = &[
+		4611686018282684417,
+		4611686018326724609,
+		4611686018309947393,
+	];
+	static P: &[u64; 5] = &[
+		1153,
+		4611686018257518593,
+		4611686018232352769,
+		4611686018171535361,
+		4611686018106523649,
+	];
 
 	#[test]
 	fn test_constructor() {
@@ -139,20 +153,32 @@ mod tests {
 	#[test]
 	fn test_converter() {
 		let ntests = 100;
-		let q = RnsContext::new(&[4, 15, 1153]).unwrap();
-		let q_product = 4u64 * 15 * 1153;
-		let p = RnsContext::new(&[7, 13, 907]).unwrap();
+		let q = RnsContext::new(Q).unwrap();
+		let p = RnsContext::new(P).unwrap();
 		let converter = RnsConverter::new(&q, &p);
 
-		let a = converter.convert(&ArrayView1::from(&[0, 0, 0]));
-		assert_eq!(a, &[0, 0, 0]);
+		let a = converter.convert_new(&(&[0, 0, 0]).into());
+		assert_eq!(a, &[0, 0, 0, 0, 0]);
+		let mut c = vec![1; 5];
+		converter.convert(&(&[0, 0, 0]).into(), &mut (&mut c).into());
+		assert_eq!(c, &[0, 0, 0, 0, 0]);
 
 		let mut rng = thread_rng();
 		for _ in 0..ntests {
-			let u = BigUint::from(rng.next_u64() % q_product);
-			let a = converter.convert(&ArrayView1::from(&q.project(&u)));
-			let b = p.project(&u);
+			let mut u = vec![];
+			for qi in Q {
+				u.push(rng.next_u64() % *qi)
+			}
+			let u_biguint = q.lift(&(&u).into());
+			let a = converter.convert_new(&(&u).into());
+			let b = if &u_biguint > &(q.modulus() >> 1u64) {
+				p.project(&(p.modulus() - q.modulus() + &u_biguint))
+			} else {
+				p.project(&u_biguint)
+			};
 			assert_eq!(&a, &b);
+			converter.convert(&(&u).into(), &mut (&mut c).into());
+			assert_eq!(&c, &b);
 		}
 	}
 }


### PR DESCRIPTION
This PR fixes several issues:
* First, #33 was comparing benchmarks where the output vector was created versus passed as input; we introduce both variants to fix that
* Second, in the variant here, we were actually storing another vector when computing the `yi`, and this was the main bottleneck. Instead, we repeat the operation (but see below).
* Finally, our unit tests were only partial and did not test the case where the rests were giving a negative value. Unfortunately it wasn't working in that case. Instead, we changed the precomputed value and algorithm for the extender to match that of scaler, and fixed the errors.

Eventually, our modifications go from
```
rns/converter/3->4      time:   [93.540 ns 93.590 ns 93.650 ns]                              
rns/scaler/3            time:   [68.079 ns 68.174 ns 68.262 ns]    
```
to 
```
rns/converter/3->4      time:   [40.296 ns 40.470 ns 40.704 ns]                               
rns/scaler/3            time:   [46.821 ns 47.330 ns 47.924 ns]  
```
and we can declare success :) 