### PR TITLE
Configures Dependabot to check for updates to Rust dependencies daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
If this generates too much noise, this should be an indication that the library has too many dependencies.