### PR TITLE
Add, Sub, and Neg and benchmarks

### DIFF
--- a/crates/bfv/Cargo.toml
+++ b/crates/bfv/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/tlepoint/fhe.rs"
 bench = false  # Disable default bench (we use criterion)
 
 [dependencies]
+itertools = "0.10.3"
 derive_builder = "0.11.2"
 math = { version = "0.0.1", path = "../math" }
 num-bigint = "0.4.3"
@@ -19,4 +20,9 @@ rand_chacha = "0.3.1"
 zeroize = { version = "1.5.7", features = ["zeroize_derive"] }
 
 [dev-dependencies]
+criterion = "0.3.6"
 proptest = "1.0.0"
+
+[[bench]]
+name = "ops"
+harness = false

--- a/crates/bfv/benches/ops.rs
+++ b/crates/bfv/benches/ops.rs
@@ -1,0 +1,73 @@
+use bfv::{
+	traits::{Encoder, Encryptor},
+	BfvParameters, BfvParametersBuilder, Encoding, Plaintext, SecretKey,
+};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use itertools::Itertools;
+use std::rc::Rc;
+
+fn params() -> Vec<Rc<BfvParameters>> {
+	let par = BfvParametersBuilder::default()
+		.polynomial_degree(16384)
+		.plaintext_modulus(2)
+		.ciphertext_moduli(vec![
+			4611686018326724609,
+			4611686018309947393,
+			4611686018282684417,
+			4611686018257518593,
+			4611686018232352769,
+			4611686018171535361,
+			4611686018106523649,
+		])
+		.build()
+		.unwrap();
+	vec![Rc::new(par)]
+}
+
+pub fn ops_benchmark(c: &mut Criterion) {
+	let mut group = c.benchmark_group("ops");
+
+	for par in params() {
+		let sk = SecretKey::random(&par);
+
+		let pt1 = Plaintext::try_encode(&(1..16u64).collect_vec(), Encoding::Poly, &par).unwrap();
+		let pt2 = Plaintext::try_encode(&(3..39u64).collect_vec(), Encoding::Poly, &par).unwrap();
+		let mut c1 = sk.encrypt(&pt1).unwrap();
+		let c2 = sk.encrypt(&pt2).unwrap();
+
+		group.bench_function(
+			BenchmarkId::new(
+				"add",
+				format!("{}/{}", par.degree(), 62 * par.moduli().len()),
+			),
+			|b| {
+				b.iter(|| c1 += &c2);
+			},
+		);
+
+		group.bench_function(
+			BenchmarkId::new(
+				"sub",
+				format!("{}/{}", par.degree(), 62 * par.moduli().len()),
+			),
+			|b| {
+				b.iter(|| c1 -= &c2);
+			},
+		);
+
+		group.bench_function(
+			BenchmarkId::new(
+				"neg",
+				format!("{}/{}", par.degree(), 62 * par.moduli().len()),
+			),
+			|b| {
+				b.iter(|| c1 = -&c2);
+			},
+		);
+	}
+
+	group.finish();
+}
+
+criterion_group!(ops, ops_benchmark);
+criterion_main!(ops);

--- a/crates/bfv/src/ciphertext.rs
+++ b/crates/bfv/src/ciphertext.rs
@@ -4,7 +4,10 @@ use crate::parameters::BfvParameters;
 use math::rq::Poly;
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
-use std::rc::Rc;
+use std::{
+	ops::{Add, AddAssign, Neg, Sub, SubAssign},
+	rc::Rc,
+};
 
 /// A ciphertext encrypting a plaintext.
 #[derive(Debug, Clone, PartialEq)]
@@ -20,4 +23,157 @@ pub struct Ciphertext {
 
 	/// The ciphertext element c1.
 	pub(crate) c1: Poly,
+}
+
+impl Add<&Ciphertext> for &Ciphertext {
+	type Output = Ciphertext;
+
+	fn add(self, rhs: &Ciphertext) -> Ciphertext {
+		debug_assert_eq!(self.par, rhs.par);
+
+		Ciphertext {
+			par: self.par.clone(),
+			seed: None,
+			c0: &self.c0 + &rhs.c0,
+			c1: &self.c1 + &rhs.c1,
+		}
+	}
+}
+
+impl AddAssign<&Ciphertext> for Ciphertext {
+	fn add_assign(&mut self, rhs: &Ciphertext) {
+		debug_assert_eq!(self.par, rhs.par);
+
+		self.c0 += &rhs.c0;
+		self.c1 += &rhs.c1;
+		self.seed = None
+	}
+}
+
+impl Sub<&Ciphertext> for &Ciphertext {
+	type Output = Ciphertext;
+
+	fn sub(self, rhs: &Ciphertext) -> Ciphertext {
+		assert_eq!(self.par, rhs.par);
+
+		Ciphertext {
+			par: self.par.clone(),
+			seed: None,
+			c0: &self.c0 - &rhs.c0,
+			c1: &self.c1 - &rhs.c1,
+		}
+	}
+}
+
+impl SubAssign<&Ciphertext> for Ciphertext {
+	fn sub_assign(&mut self, rhs: &Ciphertext) {
+		debug_assert_eq!(self.par, rhs.par);
+
+		self.c0 -= &rhs.c0;
+		self.c1 -= &rhs.c1;
+		self.seed = None
+	}
+}
+
+impl Neg for &Ciphertext {
+	type Output = Ciphertext;
+
+	fn neg(self) -> Ciphertext {
+		Ciphertext {
+			par: self.par.clone(),
+			seed: None,
+			c0: -&self.c0,
+			c1: -&self.c1,
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use crate::{
+		traits::{Decoder, Decryptor, Encoder, Encryptor},
+		BfvParameters, Encoding, Plaintext, SecretKey,
+	};
+	use proptest::collection::vec as prop_vec;
+	use proptest::prelude::any;
+	use std::rc::Rc;
+
+	proptest! {
+		#[test]
+		fn test_add(mut a in prop_vec(any::<u64>(), 8), mut b in prop_vec(any::<u64>(), 8)) {
+			for params in [Rc::new(BfvParameters::default_one_modulus()),
+						   Rc::new(BfvParameters::default_two_moduli())] {
+				params.plaintext().reduce_vec(&mut a);
+				params.plaintext().reduce_vec(&mut b);
+				let mut c = a.clone();
+				params.plaintext().add_vec(&mut c, &b);
+
+				let sk = SecretKey::random(&params);
+
+				for encoding in [Encoding::Poly, Encoding::Simd] {
+					let pt_a = Plaintext::try_encode(&a, encoding.clone(), &params).unwrap();
+					let pt_b = Plaintext::try_encode(&b, encoding.clone(), &params).unwrap();
+
+					let mut ct_a = sk.encrypt(&pt_a).unwrap();
+					let ct_b = sk.encrypt(&pt_b).unwrap();
+					let ct_c = &ct_a + &ct_b;
+					ct_a += &ct_b;
+
+					let pt_c = sk.decrypt(&ct_c).unwrap();
+					assert_eq!(Vec::<u64>::try_decode(&pt_c, encoding.clone()).unwrap(), c);
+					let pt_c = sk.decrypt(&ct_a).unwrap();
+					assert_eq!(Vec::<u64>::try_decode(&pt_c, encoding.clone()).unwrap(), c);
+				}
+			}
+		}
+
+		#[test]
+		fn test_sub(mut a in prop_vec(any::<u64>(), 8), mut b in prop_vec(any::<u64>(), 8)) {
+			for params in [Rc::new(BfvParameters::default_one_modulus()),
+						   Rc::new(BfvParameters::default_two_moduli())] {
+				params.plaintext().reduce_vec(&mut a);
+				params.plaintext().reduce_vec(&mut b);
+				let mut c = a.clone();
+				params.plaintext().sub_vec(&mut c, &b);
+
+				let sk = SecretKey::random(&params);
+
+				for encoding in [Encoding::Poly, Encoding::Simd] {
+					let pt_a = Plaintext::try_encode(&a, encoding.clone(), &params).unwrap();
+					let pt_b = Plaintext::try_encode(&b, encoding.clone(), &params).unwrap();
+
+					let mut ct_a = sk.encrypt(&pt_a).unwrap();
+					let ct_b = sk.encrypt(&pt_b).unwrap();
+					let ct_c = &ct_a - &ct_b;
+					ct_a -= &ct_b;
+
+					let pt_c = sk.decrypt(&ct_c).unwrap();
+					assert_eq!(Vec::<u64>::try_decode(&pt_c, encoding.clone()).unwrap(), c);
+					let pt_c = sk.decrypt(&ct_a).unwrap();
+					assert_eq!(Vec::<u64>::try_decode(&pt_c, encoding.clone()).unwrap(), c);
+				}
+			}
+		}
+
+		#[test]
+		fn test_neg(mut a in prop_vec(any::<u64>(), 8)) {
+			for params in [Rc::new(BfvParameters::default_one_modulus()),
+						   Rc::new(BfvParameters::default_two_moduli())] {
+				params.plaintext().reduce_vec(&mut a);
+				let mut c = a.clone();
+				params.plaintext().neg_vec(&mut c);
+
+				let sk = SecretKey::random(&params);
+				for encoding in [Encoding::Poly, Encoding::Simd] {
+					let pt_a = Plaintext::try_encode(&a, encoding.clone(), &params).unwrap();
+
+					let ct_a = sk.encrypt(&pt_a).unwrap();
+					let ct_c = -&ct_a;
+
+					let pt_c = sk.decrypt(&ct_c).unwrap();
+					assert_eq!(Vec::<u64>::try_decode(&pt_c, encoding.clone()).unwrap(), c);
+				}
+			}
+		}
+	}
 }

--- a/crates/bfv/src/lib.rs
+++ b/crates/bfv/src/lib.rs
@@ -9,8 +9,8 @@ mod ciphertext;
 mod parameters;
 mod plaintext;
 mod secret_key;
-mod traits;
 
+pub mod traits;
 pub use ciphertext::Ciphertext;
 pub use parameters::{BfvParameters, BfvParametersBuilder};
 pub use plaintext::{Encoding, Plaintext};

--- a/crates/bfv/src/parameters.rs
+++ b/crates/bfv/src/parameters.rs
@@ -45,6 +45,10 @@ pub struct BfvParameters {
 	/// Down scaler for the plaintext
 	#[builder(setter(skip))]
 	scaler: Scaler,
+
+	/// Plaintext Modulus
+	// #[builder(setter(skip))] // TODO: How can we handle this?
+	plaintext: Modulus,
 }
 
 impl BfvParameters {
@@ -54,8 +58,8 @@ impl BfvParameters {
 	}
 
 	/// Returns the underlying plaintext modulus
-	pub fn plaintext(&self) -> u64 {
-		self.plaintext_modulus
+	pub fn plaintext(&self) -> &Modulus {
+		&self.plaintext
 	}
 
 	/// Returns the error variance
@@ -199,6 +203,7 @@ impl BfvParametersBuilder {
 			op: op.map(Rc::new),
 			delta: delta_poly,
 			scaler,
+			plaintext: plaintext_modulus,
 		})
 	}
 }

--- a/crates/bfv/src/plaintext.rs
+++ b/crates/bfv/src/plaintext.rs
@@ -122,17 +122,15 @@ mod tests {
 	use super::{Encoding, Plaintext};
 	use crate::parameters::{BfvParameters, BfvParametersBuilder};
 	use crate::traits::{Decoder, Encoder};
-	use math::zq::Modulus;
 	use proptest::collection::vec as prop_vec;
-	use proptest::prelude::any;
+	use proptest::prelude::{any, ProptestConfig};
 	use std::rc::Rc;
 
 	#[test]
 	fn try_encode() {
 		// The default test parameters support both Poly and Simd encodings
 		let params = Rc::new(BfvParameters::default_one_modulus());
-		let q = Modulus::new(params.plaintext()).unwrap();
-		let a = q.random_vec(params.degree());
+		let a = params.plaintext().random_vec(params.degree());
 
 		let plaintext = Plaintext::try_encode(&[0; 9], Encoding::Poly, &params);
 		assert!(plaintext.is_err());
@@ -164,11 +162,11 @@ mod tests {
 	}
 
 	proptest! {
+		#![proptest_config(ProptestConfig::with_cases(128))]
 		#[test]
 		fn test_encode_decode(mut a in prop_vec(any::<u64>(), 8)) {
 			let params = Rc::new(BfvParameters::default_one_modulus());
-			let q = Modulus::new(params.plaintext()).unwrap();
-			q.reduce_vec(&mut a);
+			params.plaintext().reduce_vec(&mut a);
 
 			let plaintext = Plaintext::try_encode(&a, Encoding::Poly, &params);
 			assert!(plaintext.is_ok_and(|pt| pt.value == a));

--- a/crates/bfv/src/secret_key.rs
+++ b/crates/bfv/src/secret_key.rs
@@ -87,6 +87,7 @@ impl Decryptor for SecretKey {
 			c.change_representation(Representation::PowerBasis);
 			let mut d = self.par.scaler().scale(&c, false)?;
 			let mut v = Vec::<u64>::from(&d);
+			self.par.plaintext().reduce_vec(&mut v);
 			let pt = Plaintext {
 				par: self.par.clone(),
 				value: v[..self.par.degree()].to_vec(),

--- a/crates/math/src/zq/mod.rs
+++ b/crates/math/src/zq/mod.rs
@@ -340,6 +340,12 @@ impl Modulus {
 		debug_assert_eq!(r, x % p);
 
 		r
+		// TODO: Make two versions: ct and vt, benchmarks both up to the ciphertext operations...
+		// if x >= p {
+		// 	x - p
+		// } else {
+		// 	x
+		// }
 	}
 
 	/// Lazy modular reduction of a in constant time.


### PR DESCRIPTION
On ciphertexts, we can do variable time operations, and this would yield a significant speedup for these homomorphic operations. A follow-up PR will introduce vt_add, vt_sub, and vt_neg operations all across the library.