### PR TITLE
Introduce variable time computations at the polynomial level

### DIFF
--- a/crates/math/benches/zq.rs
+++ b/crates/math/benches/zq.rs
@@ -39,7 +39,7 @@ pub fn zq_benchmark(c: &mut Criterion) {
 		});
 
 		group.bench_function(BenchmarkId::new("vt_mul_vec", vector_size), |b| unsafe {
-			b.iter(|| q.vt_mul_vec(&mut a, &c));
+			b.iter(|| q.mul_vec_vt(&mut a, &c));
 		});
 	}
 

--- a/crates/math/src/rq/extender.rs
+++ b/crates/math/src/rq/extender.rs
@@ -77,6 +77,7 @@ impl ContextSwitcher for Extender {
 			Ok(Poly {
 				ctx: self.to.clone(),
 				representation: Representation::PowerBasis,
+				allow_variable_time_computations: p.allow_variable_time_computations,
 				coefficients: new_coefficients,
 				coefficients_shoup: None,
 			})

--- a/crates/math/src/rq/scaler.rs
+++ b/crates/math/src/rq/scaler.rs
@@ -52,6 +52,7 @@ impl Scaler {
 			Ok(Poly {
 				ctx: p.ctx.clone(),
 				representation: Representation::PowerBasis,
+				allow_variable_time_computations: p.allow_variable_time_computations,
 				coefficients: new_coefficients,
 				coefficients_shoup: None,
 			})


### PR DESCRIPTION
On Apple M2, this improves the performances for homomorphic operations as follows:
```
ops/add/16384/434       time:   [50.286 µs 50.358 µs 50.436 µs]                               
                        change: [-27.465% -27.226% -27.015%] (p = 0.00 < 0.05)
                        Performance has improved.
ops/sub/16384/434       time:   [50.383 µs 50.407 µs 50.437 µs]                               
                        change: [-26.724% -26.589% -26.429%] (p = 0.00 < 0.05)
                        Performance has improved.
ops/neg/16384/434       time:   [59.612 µs 59.666 µs 59.744 µs]                              
                        change: [-39.414% -38.964% -38.528%] (p = 0.00 < 0.05)
                        Performance has improved.
```