### PR TITLE
Fix scaler and switch to more moduli for tests

### DIFF
--- a/crates/fhers/src/bfv/ciphertext.rs
+++ b/crates/fhers/src/bfv/ciphertext.rs
@@ -216,7 +216,7 @@ mod tests {
 	fn proto_conversion() -> Result<(), Box<dyn Error>> {
 		for params in [
 			Arc::new(BfvParameters::default(1, 8)),
-			Arc::new(BfvParameters::default(2, 8)),
+			Arc::new(BfvParameters::default(6, 8)),
 		] {
 			let sk = SecretKey::random(&params);
 			let v = params.plaintext.random_vec(params.degree());
@@ -236,7 +236,7 @@ mod tests {
 	fn serialize() -> Result<(), Box<dyn Error>> {
 		for params in [
 			Arc::new(BfvParameters::default(1, 8)),
-			Arc::new(BfvParameters::default(2, 8)),
+			Arc::new(BfvParameters::default(6, 8)),
 		] {
 			let sk = SecretKey::random(&params);
 			let v = params.plaintext.random_vec(params.degree());
@@ -252,7 +252,7 @@ mod tests {
 	fn new() -> Result<(), Box<dyn Error>> {
 		for params in [
 			Arc::new(BfvParameters::default(1, 8)),
-			Arc::new(BfvParameters::default(2, 8)),
+			Arc::new(BfvParameters::default(6, 8)),
 		] {
 			let sk = SecretKey::random(&params);
 			let v = params.plaintext.random_vec(params.degree());
@@ -289,7 +289,7 @@ mod tests {
 	fn mod_switch_to_last_level() -> Result<(), Box<dyn Error>> {
 		for params in [
 			Arc::new(BfvParameters::default(1, 8)),
-			Arc::new(BfvParameters::default(2, 8)),
+			Arc::new(BfvParameters::default(6, 8)),
 		] {
 			let sk = SecretKey::random(&params);
 			let v = params.plaintext.random_vec(params.degree());

--- a/crates/fhers/src/bfv/keys/evaluation_key.rs
+++ b/crates/fhers/src/bfv/keys/evaluation_key.rs
@@ -491,7 +491,7 @@ mod tests {
 
 	#[test]
 	fn builder() -> Result<(), Box<dyn Error>> {
-		let params = Arc::new(BfvParameters::default(2, 8));
+		let params = Arc::new(BfvParameters::default(6, 8));
 		let sk = SecretKey::random(&params);
 		for ciphertext_level in 0..=params.max_level() {
 			for evaluation_key_level in 0..=min(params.max_level() - 1, ciphertext_level) {
@@ -549,12 +549,14 @@ mod tests {
 			}
 		}
 
-		assert!(EvaluationKeyBuilder::new_leveled(&sk, 1, 1)?
-			.enable_inner_sum()
-			.is_err_and(|e| e
-				== &crate::Error::DefaultError(
-					"Not enough moduli to enable relinearization".to_string()
-				)));
+		assert!(
+			EvaluationKeyBuilder::new_leveled(&sk, params.max_level(), params.max_level())?
+				.enable_inner_sum()
+				.is_err_and(|e| e
+					== &crate::Error::DefaultError(
+						"Not enough moduli to enable relinearization".to_string()
+					))
+		);
 
 		assert!(EvaluationKeyBuilder::new_leveled(&sk, 0, 1)
 			.is_err_and(|e| e == &crate::Error::DefaultError("Unexpected levels".to_string())));
@@ -565,7 +567,7 @@ mod tests {
 	#[test]
 	fn inner_sum() -> Result<(), Box<dyn Error>> {
 		for params in [
-			Arc::new(BfvParameters::default(2, 8)),
+			Arc::new(BfvParameters::default(6, 8)),
 			Arc::new(BfvParameters::default(5, 8)),
 		] {
 			for _ in 0..25 {
@@ -608,7 +610,7 @@ mod tests {
 	#[test]
 	fn row_rotation() -> Result<(), Box<dyn Error>> {
 		for params in [
-			Arc::new(BfvParameters::default(2, 8)),
+			Arc::new(BfvParameters::default(6, 8)),
 			Arc::new(BfvParameters::default(5, 8)),
 		] {
 			for _ in 0..50 {
@@ -652,7 +654,7 @@ mod tests {
 	#[test]
 	fn column_rotation() -> Result<(), Box<dyn Error>> {
 		for params in [
-			Arc::new(BfvParameters::default(2, 8)),
+			Arc::new(BfvParameters::default(6, 8)),
 			Arc::new(BfvParameters::default(5, 8)),
 		] {
 			let row_size = params.degree() >> 1;
@@ -708,7 +710,7 @@ mod tests {
 	#[test]
 	fn expansion() -> Result<(), Box<dyn Error>> {
 		for params in [
-			Arc::new(BfvParameters::default(2, 8)),
+			Arc::new(BfvParameters::default(6, 8)),
 			Arc::new(BfvParameters::default(5, 8)),
 		] {
 			let log_degree = 64 - 1 - params.degree().leading_zeros();
@@ -764,7 +766,7 @@ mod tests {
 	fn proto_conversion() -> Result<(), Box<dyn Error>> {
 		for params in [
 			Arc::new(BfvParameters::default(1, 8)),
-			Arc::new(BfvParameters::default(2, 8)),
+			Arc::new(BfvParameters::default(6, 8)),
 			Arc::new(BfvParameters::default(5, 8)),
 		] {
 			let sk = SecretKey::random(&params);
@@ -807,7 +809,7 @@ mod tests {
 	fn serialize() -> Result<(), Box<dyn Error>> {
 		for params in [
 			Arc::new(BfvParameters::default(1, 8)),
-			Arc::new(BfvParameters::default(2, 8)),
+			Arc::new(BfvParameters::default(6, 8)),
 		] {
 			let sk = SecretKey::random(&params);
 

--- a/crates/fhers/src/bfv/keys/galois_key.rs
+++ b/crates/fhers/src/bfv/keys/galois_key.rs
@@ -131,7 +131,7 @@ mod tests {
 	#[test]
 	fn relinearization() -> Result<(), Box<dyn Error>> {
 		for params in [
-			Arc::new(BfvParameters::default(2, 8)),
+			Arc::new(BfvParameters::default(6, 8)),
 			Arc::new(BfvParameters::default(3, 8)),
 		] {
 			for _ in 0..30 {
@@ -180,7 +180,7 @@ mod tests {
 	#[test]
 	fn proto_conversion() -> Result<(), Box<dyn Error>> {
 		for params in [
-			Arc::new(BfvParameters::default(2, 8)),
+			Arc::new(BfvParameters::default(6, 8)),
 			Arc::new(BfvParameters::default(4, 8)),
 		] {
 			let sk = SecretKey::random(&params);

--- a/crates/fhers/src/bfv/keys/key_switching_key.rs
+++ b/crates/fhers/src/bfv/keys/key_switching_key.rs
@@ -256,7 +256,7 @@ mod tests {
 	#[test]
 	fn constructor() -> Result<(), Box<dyn Error>> {
 		for params in [
-			Arc::new(BfvParameters::default(2, 8)),
+			Arc::new(BfvParameters::default(6, 8)),
 			Arc::new(BfvParameters::default(3, 8)),
 		] {
 			let sk = SecretKey::random(&params);
@@ -270,7 +270,7 @@ mod tests {
 
 	#[test]
 	fn key_switch() -> Result<(), Box<dyn Error>> {
-		for params in [Arc::new(BfvParameters::default(2, 8))] {
+		for params in [Arc::new(BfvParameters::default(6, 8))] {
 			for _ in 0..100 {
 				let sk = SecretKey::random(&params);
 				let ctx = params.ctx_at_level(0)?;
@@ -308,7 +308,7 @@ mod tests {
 	#[test]
 	fn proto_conversion() -> Result<(), Box<dyn Error>> {
 		for params in [
-			Arc::new(BfvParameters::default(2, 8)),
+			Arc::new(BfvParameters::default(6, 8)),
 			Arc::new(BfvParameters::default(3, 8)),
 		] {
 			let sk = SecretKey::random(&params);

--- a/crates/fhers/src/bfv/keys/public_key.rs
+++ b/crates/fhers/src/bfv/keys/public_key.rs
@@ -58,10 +58,10 @@ impl FheEncrypter<Plaintext, Ciphertext> for PublicKey {
 			Poly::small(ctx, Representation::Ntt, self.par.variance).map_err(Error::MathError)?;
 
 		let mut m = pt.to_poly()?;
-		let mut c0 = &u * &self.c.c[0];
+		let mut c0 = &u * &ct.c[0];
 		c0 += &e1;
 		c0 += &m;
-		let mut c1 = &u * &self.c.c[1];
+		let mut c1 = &u * &ct.c[1];
 		c1 += &e2;
 
 		// Zeroize the temporary variables holding sensitive information.
@@ -151,7 +151,7 @@ mod tests {
 	fn encrypt_decrypt() -> Result<(), Box<dyn Error>> {
 		for params in [
 			Arc::new(BfvParameters::default(1, 8)),
-			Arc::new(BfvParameters::default(2, 8)),
+			Arc::new(BfvParameters::default(6, 8)),
 		] {
 			for level in 0..params.max_level() {
 				for _ in 0..20 {
@@ -179,7 +179,7 @@ mod tests {
 	fn test_serialize() -> Result<(), Box<dyn Error>> {
 		for params in [
 			Arc::new(BfvParameters::default(1, 8)),
-			Arc::new(BfvParameters::default(2, 8)),
+			Arc::new(BfvParameters::default(6, 8)),
 		] {
 			let sk = SecretKey::random(&params);
 			let pk = PublicKey::new(&sk)?;

--- a/crates/fhers/src/bfv/keys/relinearization_key.rs
+++ b/crates/fhers/src/bfv/keys/relinearization_key.rs
@@ -162,7 +162,7 @@ mod tests {
 
 	#[test]
 	fn relinearization() -> Result<(), Box<dyn Error>> {
-		for params in [Arc::new(BfvParameters::default(2, 8))] {
+		for params in [Arc::new(BfvParameters::default(6, 8))] {
 			for _ in 0..100 {
 				let sk = SecretKey::random(&params);
 				let rk = RelinearizationKey::new(&sk)?;
@@ -271,7 +271,7 @@ mod tests {
 	#[test]
 	fn proto_conversion() -> Result<(), Box<dyn Error>> {
 		for params in [
-			Arc::new(BfvParameters::default(2, 8)),
+			Arc::new(BfvParameters::default(6, 8)),
 			Arc::new(BfvParameters::default(3, 8)),
 		] {
 			let sk = SecretKey::random(&params);

--- a/crates/fhers/src/bfv/keys/secret_key.rs
+++ b/crates/fhers/src/bfv/keys/secret_key.rs
@@ -249,7 +249,7 @@ mod tests {
 	fn encrypt_decrypt() -> Result<(), Box<dyn Error>> {
 		for params in [
 			Arc::new(BfvParameters::default(1, 8)),
-			Arc::new(BfvParameters::default(2, 8)),
+			Arc::new(BfvParameters::default(6, 8)),
 		] {
 			for level in 0..params.max_level() {
 				for _ in 0..20 {

--- a/crates/fhers/src/bfv/ops/mod.rs
+++ b/crates/fhers/src/bfv/ops/mod.rs
@@ -288,7 +288,7 @@ mod tests {
 	fn add() -> Result<(), Box<dyn Error>> {
 		for params in [
 			Arc::new(BfvParameters::default(1, 8)),
-			Arc::new(BfvParameters::default(2, 8)),
+			Arc::new(BfvParameters::default(6, 8)),
 		] {
 			let zero = Ciphertext::zero(&params);
 			for _ in 0..50 {
@@ -325,7 +325,7 @@ mod tests {
 	fn add_scalar() -> Result<(), Box<dyn Error>> {
 		for params in [
 			Arc::new(BfvParameters::default(1, 8)),
-			Arc::new(BfvParameters::default(2, 8)),
+			Arc::new(BfvParameters::default(6, 8)),
 		] {
 			for _ in 0..50 {
 				let a = params.plaintext.random_vec(params.degree());
@@ -373,7 +373,7 @@ mod tests {
 	fn sub() -> Result<(), Box<dyn Error>> {
 		for params in [
 			Arc::new(BfvParameters::default(1, 8)),
-			Arc::new(BfvParameters::default(2, 8)),
+			Arc::new(BfvParameters::default(6, 8)),
 		] {
 			let zero = Ciphertext::zero(&params);
 			for _ in 0..50 {
@@ -418,7 +418,7 @@ mod tests {
 	fn sub_scalar() -> Result<(), Box<dyn Error>> {
 		for params in [
 			Arc::new(BfvParameters::default(1, 8)),
-			Arc::new(BfvParameters::default(2, 8)),
+			Arc::new(BfvParameters::default(6, 8)),
 		] {
 			for _ in 0..50 {
 				let a = params.plaintext.random_vec(params.degree());
@@ -468,7 +468,7 @@ mod tests {
 	fn neg() -> Result<(), Box<dyn Error>> {
 		for params in [
 			Arc::new(BfvParameters::default(1, 8)),
-			Arc::new(BfvParameters::default(2, 8)),
+			Arc::new(BfvParameters::default(6, 8)),
 		] {
 			for _ in 0..50 {
 				let a = params.plaintext.random_vec(params.degree());
@@ -499,7 +499,7 @@ mod tests {
 	fn mul_scalar() -> Result<(), Box<dyn Error>> {
 		for params in [
 			Arc::new(BfvParameters::default(1, 8)),
-			Arc::new(BfvParameters::default(2, 8)),
+			Arc::new(BfvParameters::default(6, 8)),
 		] {
 			for _ in 0..50 {
 				let a = params.plaintext.random_vec(params.degree());
@@ -551,7 +551,7 @@ mod tests {
 
 	#[test]
 	fn mul() -> Result<(), Box<dyn Error>> {
-		let par = Arc::new(BfvParameters::default(2, 8));
+		let par = Arc::new(BfvParameters::default(8, 8));
 		for _ in 0..20 {
 			// We will encode `values` in an Simd format, and check that the product is
 			// computed correctly.
@@ -584,7 +584,7 @@ mod tests {
 
 	#[test]
 	fn square() -> Result<(), Box<dyn Error>> {
-		let par = Arc::new(BfvParameters::default(2, 8));
+		let par = Arc::new(BfvParameters::default(6, 8));
 		for _ in 0..20 {
 			// We will encode `values` in an Simd format, and check that the product is
 			// computed correctly.

--- a/crates/fhers/src/bfv/ops/mul.rs
+++ b/crates/fhers/src/bfv/ops/mul.rs
@@ -317,7 +317,7 @@ mod tests {
 
 	#[test]
 	fn mul_no_relin() -> Result<(), Box<dyn Error>> {
-		let par = Arc::new(BfvParameters::default(2, 8));
+		let par = Arc::new(BfvParameters::default(6, 8));
 		for _ in 0..30 {
 			// We will encode `values` in an Simd format, and check that the product is
 			// computed correctly.

--- a/crates/fhers/src/bfv/rgsw_ciphertext.rs
+++ b/crates/fhers/src/bfv/rgsw_ciphertext.rs
@@ -158,7 +158,7 @@ mod tests {
 	#[test]
 	fn external_product() -> Result<(), Box<dyn Error>> {
 		for params in [
-			Arc::new(BfvParameters::default(2, 8)),
+			Arc::new(BfvParameters::default(6, 8)),
 			Arc::new(BfvParameters::default(8, 8)),
 		] {
 			let sk = SecretKey::random(&params);
@@ -189,7 +189,7 @@ mod tests {
 	#[test]
 	fn serialize() -> Result<(), Box<dyn Error>> {
 		for params in [
-			Arc::new(BfvParameters::default(2, 8)),
+			Arc::new(BfvParameters::default(6, 8)),
 			Arc::new(BfvParameters::default(5, 8)),
 		] {
 			let sk = SecretKey::random(&params);


### PR DESCRIPTION
The scaler was broken since https://github.com/tlepoint/fhe.rs/commit/ec7b06023a8eb55d0538cd969152e53b87d90814 and this was only visible when the value `v` was larger than `2^64`, which happens when we use more moduli. We change all the tests to use more moduli...