### PR TITLE
Use `concrete-ntt` for NTT operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "aligned-vec"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aa90d7ce82d4be67b64039a3d588d38dbcc6736577de4a847025ce5b0c468d1"
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -76,6 +82,12 @@ name = "bumpalo"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+
+[[package]]
+name = "bytemuck"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2490600f404f2b94c167e31d3ed1d5f3c225a0f3b80230053b3e0b7b962bd9"
 
 [[package]]
 name = "byteorder"
@@ -152,6 +164,16 @@ name = "clap_lex"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
+
+[[package]]
+name = "concrete-ntt"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1167c583765f273205c691a0a8bff23a925aa5bc66f2448031e4a6e518cd64d7"
+dependencies = [
+ "aligned-vec",
+ "pulp",
+]
 
 [[package]]
 name = "console"
@@ -338,6 +360,7 @@ dependencies = [
 name = "fhe-math"
 version = "0.1.0-beta.8"
 dependencies = [
+ "concrete-ntt",
  "criterion",
  "ethnum",
  "fhe-traits",
@@ -830,6 +853,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "193898f59edcf43c26227dcd4c8427f00d99d61e95dcde58dabd49fa291d470e"
 dependencies = [
  "prost",
+]
+
+[[package]]
+name = "pulp"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "866e8018d6397b0717100dd4a7948fc8cbc8c4b8ce3e39e98a0e1e878d3ba925"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ license = "MIT"
 rust-version = "1.73"
 
 [workspace.dependencies]
+concrete-ntt = "^0.1.1"
 console = "^0.15.8"
 criterion = "^0.5.1"
 doc-comment = "^0.3.3"

--- a/crates/fhe-math/Cargo.toml
+++ b/crates/fhe-math/Cargo.toml
@@ -12,10 +12,15 @@ rust-version.workspace = true
 [lib]
 bench = false  # Disable default bench (we use criterion)
 
+[features]
+concrete-ntt = []
+concrete-ntt-nightly = ["concrete-ntt/nightly"]
+
 [dependencies]
 fhe-traits = { version = "^0.1.0-beta.8", path = "../fhe-traits" }
 fhe-util = { version = "^0.1.0-beta.8", path = "../fhe-util" }
 
+concrete-ntt.workspace = true
 ethnum.workspace = true
 itertools.workspace = true
 ndarray.workspace = true

--- a/crates/fhe-math/src/ntt/concrete.rs
+++ b/crates/fhe-math/src/ntt/concrete.rs
@@ -1,0 +1,105 @@
+use concrete_ntt::prime64::Plan;
+
+use crate::zq::Modulus;
+
+use super::native;
+
+/// Number-Theoretic Transform operator.
+#[derive(Debug, Clone)]
+pub struct NttOperator {
+    concrete_operator: Option<Plan>,
+    native_operator: native::NttOperator,
+}
+
+impl PartialEq for NttOperator {
+    fn eq(&self, other: &Self) -> bool {
+        self.native_operator == other.native_operator
+    }
+}
+
+impl Eq for NttOperator {}
+
+impl NttOperator {
+    /// Create an NTT operator given a modulus for a specific size.
+    ///
+    /// Aborts if the size is not a power of 2 that is >= 8 in debug mode.
+    /// Returns None if the modulus does not support the NTT for this specific
+    /// size.
+    pub fn new(p: &Modulus, size: usize) -> Option<Self> {
+        let native_operator = native::NttOperator::new(p, size)?;
+        let concrete_operator = Plan::try_new(size, p.p);
+        Some(Self {
+            concrete_operator,
+            native_operator,
+        })
+    }
+
+    /// Compute the forward NTT in place.
+    /// Aborts if a is not of the size handled by the operator.
+    pub fn forward(&self, a: &mut [u64]) {
+        if let Some(ref concrete_operator) = self.concrete_operator {
+            concrete_operator.fwd(a);
+        } else {
+            self.native_operator.forward(a);
+        }
+    }
+
+    /// Compute the backward NTT in place.
+    /// Aborts if a is not of the size handled by the operator.
+    pub fn backward(&self, a: &mut [u64]) {
+        if let Some(ref concrete_operator) = self.concrete_operator {
+            concrete_operator.inv(a);
+            concrete_operator.normalize(a);
+        } else {
+            self.native_operator.backward(a);
+        }
+    }
+
+    /// Compute the forward NTT in place in variable time in a lazily fashion.
+    /// This means that the output coefficients may be up to 4 times the
+    /// modulus.
+    ///
+    /// # Safety
+    /// This function assumes that a_ptr points to at least `size` elements.
+    /// This function is not constant time and its timing may reveal information
+    /// about the value being reduced.
+    pub(crate) unsafe fn forward_vt_lazy(&self, a_ptr: *mut u64) {
+        if let Some(ref concrete_operator) = self.concrete_operator {
+            let a = std::slice::from_raw_parts_mut(a_ptr, concrete_operator.ntt_size());
+            concrete_operator.fwd(a);
+        } else {
+            self.native_operator.forward_vt_lazy(a_ptr);
+        }
+    }
+
+    /// Compute the forward NTT in place in variable time.
+    ///
+    /// # Safety
+    /// This function assumes that a_ptr points to at least `size` elements.
+    /// This function is not constant time and its timing may reveal information
+    /// about the value being reduced.
+    pub unsafe fn forward_vt(&self, a_ptr: *mut u64) {
+        if let Some(ref concrete_operator) = self.concrete_operator {
+            let a = std::slice::from_raw_parts_mut(a_ptr, concrete_operator.ntt_size());
+            concrete_operator.fwd(a);
+        } else {
+            self.native_operator.forward_vt(a_ptr);
+        }
+    }
+
+    /// Compute the backward NTT in place in variable time.
+    ///
+    /// # Safety
+    /// This function assumes that a_ptr points to at least `size` elements.
+    /// This function is not constant time and its timing may reveal information
+    /// about the value being reduced.
+    pub unsafe fn backward_vt(&self, a_ptr: *mut u64) {
+        if let Some(ref concrete_operator) = self.concrete_operator {
+            let a = std::slice::from_raw_parts_mut(a_ptr, concrete_operator.ntt_size());
+            concrete_operator.inv(a);
+            concrete_operator.normalize(a);
+        } else {
+            self.native_operator.backward_vt(a_ptr);
+        }
+    }
+}

--- a/crates/fhe-math/src/ntt/mod.rs
+++ b/crates/fhe-math/src/ntt/mod.rs
@@ -3,6 +3,13 @@
 use fhe_util::is_prime;
 
 mod native;
+
+#[cfg(any(feature = "concrete-ntt", feature = "concrete-ntt-nightly"))]
+mod concrete;
+
+#[cfg(any(feature = "concrete-ntt", feature = "concrete-ntt-nightly"))]
+pub use concrete::NttOperator;
+#[cfg(not(any(feature = "concrete-ntt", feature = "concrete-ntt-nightly")))]
 pub use native::NttOperator;
 
 /// Returns whether a modulus p is prime and supports the Number Theoretic


### PR DESCRIPTION
We allow the use of `concrete-ntt` in `fhe-math` crate via the feature flags
* `concrete-ntt`
* `concrete-ntt-nightly`

Benchmarks to be added to this PR.