### PR TITLE
Remove variable time computations

### DIFF
--- a/crates/fhe-math/benches/ntt.rs
+++ b/crates/fhe-math/benches/ntt.rs
@@ -21,18 +21,8 @@ pub fn ntt_benchmark(c: &mut Criterion) {
             );
 
             group.bench_function(
-                BenchmarkId::new("forward_vt", format!("{vector_size}/{p_nbits}")),
-                |b| b.iter(|| unsafe { op.forward_vt(a.as_mut_ptr()) }),
-            );
-
-            group.bench_function(
                 BenchmarkId::new("backward", format!("{vector_size}/{p_nbits}")),
                 |b| b.iter(|| op.backward(&mut a)),
-            );
-
-            group.bench_function(
-                BenchmarkId::new("backward_vt", format!("{vector_size}/{p_nbits}")),
-                |b| b.iter(|| unsafe { op.backward_vt(a.as_mut_ptr()) }),
             );
         }
     }

--- a/crates/fhe-math/benches/zq.rs
+++ b/crates/fhe-math/benches/zq.rs
@@ -20,10 +20,6 @@ pub fn zq_benchmark(c: &mut Criterion) {
             b.iter(|| q.add_vec(&mut a, &c));
         });
 
-        group.bench_function(BenchmarkId::new("add_vec_vt", vector_size), |b| unsafe {
-            b.iter(|| q.add_vec_vt(&mut a, &c));
-        });
-
         group.bench_function(BenchmarkId::new("sub_vec", vector_size), |b| {
             b.iter(|| q.sub_vec(&mut a, &c));
         });
@@ -34,10 +30,6 @@ pub fn zq_benchmark(c: &mut Criterion) {
 
         group.bench_function(BenchmarkId::new("mul_vec", vector_size), |b| {
             b.iter(|| q.mul_vec(&mut a, &c));
-        });
-
-        group.bench_function(BenchmarkId::new("mul_vec_vt", vector_size), |b| unsafe {
-            b.iter(|| q.mul_vec_vt(&mut a, &c));
         });
 
         group.bench_function(BenchmarkId::new("mul_shoup_vec", vector_size), |b| {

--- a/crates/fhe-math/src/ntt/mod.rs
+++ b/crates/fhe-math/src/ntt/mod.rs
@@ -55,19 +55,12 @@ mod tests {
                     for _ in 0..ntests {
                         let mut a = q.random_vec(size, &mut rng);
                         let a_clone = a.clone();
-                        let mut b = a.clone();
 
                         op.forward(&mut a);
                         assert_ne!(a, a_clone);
 
-                        unsafe { op.forward_vt(b.as_mut_ptr()) }
-                        assert_eq!(a, b);
-
                         op.backward(&mut a);
                         assert_eq!(a, a_clone);
-
-                        unsafe { op.backward_vt(b.as_mut_ptr()) }
-                        assert_eq!(a, b);
                     }
                 }
             }
@@ -91,11 +84,8 @@ mod tests {
                         let mut a_lazy = a.clone();
 
                         op.forward(&mut a);
-
-                        unsafe {
-                            op.forward_vt_lazy(a_lazy.as_mut_ptr());
-                            q.reduce_vec(&mut a_lazy);
-                        }
+                        op.forward_lazy(&mut a_lazy);
+                        q.reduce_vec(&mut a_lazy);
 
                         assert_eq!(a, a_lazy);
                     }

--- a/crates/fhe-math/src/proto/rq.proto
+++ b/crates/fhe-math/src/proto/rq.proto
@@ -13,5 +13,4 @@ message Rq {
     Representation representation = 1;
     uint32 degree = 2;
     bytes coefficients = 3;
-    bool allow_variable_time = 4;
 }

--- a/crates/fhe-math/src/proto/rq.rs
+++ b/crates/fhe-math/src/proto/rq.rs
@@ -9,8 +9,6 @@ pub struct Rq {
     pub degree: u32,
     #[prost(bytes = "vec", tag = "3")]
     pub coefficients: ::prost::alloc::vec::Vec<u8>,
-    #[prost(bool, tag = "4")]
-    pub allow_variable_time: bool,
 }
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]

--- a/crates/fhe-math/src/rq/scaler.rs
+++ b/crates/fhe-math/src/rq/scaler.rs
@@ -83,13 +83,8 @@ impl Scaler {
                 } else if self.number_common_moduli < self.to.q.len() {
                     let mut p_coefficients_powerbasis = p.coefficients.clone();
                     // Backward NTT
-                    if p.allow_variable_time_computations {
-                        izip!(p_coefficients_powerbasis.outer_iter_mut(), p.ctx.ops.iter())
-                            .for_each(|(mut v, op)| unsafe { op.backward_vt(v.as_mut_ptr()) });
-                    } else {
-                        izip!(p_coefficients_powerbasis.outer_iter_mut(), p.ctx.ops.iter())
-                            .for_each(|(mut v, op)| op.backward(v.as_slice_mut().unwrap()));
-                    }
+                    izip!(p_coefficients_powerbasis.outer_iter_mut(), p.ctx.ops.iter())
+                        .for_each(|(mut v, op)| op.backward(v.as_slice_mut().unwrap()));
                     // Conversion
                     izip!(
                         new_coefficients
@@ -102,30 +97,19 @@ impl Scaler {
                             .scale(column, new_column, self.number_common_moduli)
                     });
                     // Forward NTT on the second half
-                    if p.allow_variable_time_computations {
-                        izip!(
-                            new_coefficients
-                                .slice_mut(s![self.number_common_moduli.., ..])
-                                .outer_iter_mut(),
-                            &self.to.ops[self.number_common_moduli..]
-                        )
-                        .for_each(|(mut v, op)| unsafe { op.forward_vt(v.as_mut_ptr()) });
-                    } else {
-                        izip!(
-                            new_coefficients
-                                .slice_mut(s![self.number_common_moduli.., ..])
-                                .outer_iter_mut(),
-                            &self.to.ops[self.number_common_moduli..]
-                        )
-                        .for_each(|(mut v, op)| op.forward(v.as_slice_mut().unwrap()));
-                    }
+                    izip!(
+                        new_coefficients
+                            .slice_mut(s![self.number_common_moduli.., ..])
+                            .outer_iter_mut(),
+                        &self.to.ops[self.number_common_moduli..]
+                    )
+                    .for_each(|(mut v, op)| op.forward(v.as_slice_mut().unwrap()));
                 }
             }
 
             Ok(Poly {
                 ctx: self.to.clone(),
                 representation,
-                allow_variable_time_computations: p.allow_variable_time_computations,
                 coefficients: new_coefficients,
                 coefficients_shoup: None,
                 has_lazy_coefficients: false,

--- a/crates/fhe-math/src/rq/serialize.rs
+++ b/crates/fhe-math/src/rq/serialize.rs
@@ -19,7 +19,7 @@ impl DeserializeWithContext for Poly {
 
     fn from_bytes(bytes: &[u8], ctx: &Arc<Context>) -> Result<Self, Self::Error> {
         let rq: Rq = Message::decode(bytes).map_err(|e| Error::Serialization(e.to_string()))?;
-        Poly::try_convert_from(&rq, ctx, false, None)
+        Poly::try_convert_from(&rq, ctx, None)
     }
 }
 

--- a/crates/fhe-math/src/rq/traits.rs
+++ b/crates/fhe-math/src/rq/traits.rs
@@ -21,12 +21,7 @@ where
     /// be specified as `None`; this is useful for example when converting from
     /// a value that encodes the representation (e.g., serialization, protobuf,
     /// etc.).
-    fn try_convert_from<R>(
-        value: T,
-        ctx: &Arc<Context>,
-        variable_time: bool,
-        representation: R,
-    ) -> Result<Self>
+    fn try_convert_from<R>(value: T, ctx: &Arc<Context>, representation: R) -> Result<Self>
     where
         R: Into<Option<Representation>>;
 }

--- a/crates/fhe-traits/src/lib.rs
+++ b/crates/fhe-traits/src/lib.rs
@@ -58,25 +58,6 @@ where
     ) -> Result<Self, Self::Error>;
 }
 
-/// Encode a value using a specified encoding.
-pub trait FheEncoderVariableTime<V>
-where
-    Self: FhePlaintext,
-{
-    /// The type of error returned.
-    type Error;
-
-    /// Attempt to encode a value using a specified encoding.
-    /// # Safety
-    /// This encoding runs in variable time and may leak information about the
-    /// value.
-    unsafe fn try_encode_vt(
-        value: V,
-        encoding: Self::Encoding,
-        par: &Arc<Self::Parameters>,
-    ) -> Result<Self, Self::Error>;
-}
-
 /// Decode the value in the plaintext with the specified (optional) encoding.
 pub trait FheDecoder<P: FhePlaintext>
 where

--- a/crates/fhe/examples/sealpir.rs
+++ b/crates/fhe/examples/sealpir.rs
@@ -13,8 +13,7 @@ use clap::Parser;
 use fhe::bfv;
 use fhe_math::rq::{traits::TryConvertFrom, Context, Poly, Representation};
 use fhe_traits::{
-    DeserializeParametrized, FheDecoder, FheDecrypter, FheEncoder, FheEncoderVariableTime,
-    FheEncrypter, Serialize,
+    DeserializeParametrized, FheDecoder, FheDecrypter, FheEncoder, FheEncrypter, Serialize,
 };
 use fhe_util::{inverse, transcode_bidirectional, transcode_to_bytes};
 use indicatif::HumanBytes;
@@ -180,14 +179,12 @@ fn main() -> Result<(), Box<dyn Error>> {
                     64 - params.moduli()[0].leading_zeros() as usize,
                     plaintext_modulus.ilog2() as usize,
                 ));
-                unsafe {
-                    Ok(bfv::PlaintextVec::try_encode_vt(
-                        &pt_values,
-                        bfv::Encoding::poly_at_level(1),
-                        &params,
-                    )?
-                    .0)
-                }
+                Ok(bfv::PlaintextVec::try_encode(
+                    &pt_values,
+                    bfv::Encoding::poly_at_level(1),
+                    &params,
+                )?
+                .0)
             })
             .collect::<fhe::Result<Vec<Vec<bfv::Plaintext>>>>()?;
         (0..fold[0].len())
@@ -246,8 +243,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         let ctx = Arc::new(Context::new(&params.moduli()[..1], params.degree())?);
         let ct = bfv::Ciphertext::new(
             vec![
-                Poly::try_convert_from(poly0, &ctx, true, Representation::Ntt)?,
-                Poly::try_convert_from(poly1, &ctx, true, Representation::Ntt)?,
+                Poly::try_convert_from(poly0, &ctx, Representation::Ntt)?,
+                Poly::try_convert_from(poly1, &ctx, Representation::Ntt)?,
             ],
             &params,
         )?;

--- a/crates/fhe/src/bfv/ciphertext.rs
+++ b/crates/fhe/src/bfv/ciphertext.rs
@@ -176,8 +176,7 @@ impl TryConvertFrom<&CiphertextProto> for Ciphertext {
                     ))
                 })?;
             seed = Some(try_seed);
-            let mut c1 = Poly::random_from_seed(ctx, Representation::Ntt, try_seed);
-            unsafe { c1.allow_variable_time_computations() }
+            let c1 = Poly::random_from_seed(ctx, Representation::Ntt, try_seed);
             c.push(c1)
         }
 

--- a/crates/fhe/src/bfv/keys/evaluation_key.rs
+++ b/crates/fhe/src/bfv/keys/evaluation_key.rs
@@ -343,13 +343,8 @@ impl EvaluationKeyBuilder {
         for l in 0..self.sk.par.degree().ilog2() {
             let mut monomial = vec![0i64; self.sk.par.degree()];
             monomial[self.sk.par.degree() - (1 << l)] = -1;
-            let mut monomial = Poly::try_convert_from(
-                &monomial,
-                ciphertext_ctx,
-                true,
-                Representation::PowerBasis,
-            )?;
-            unsafe { monomial.allow_variable_time_computations() }
+            let mut monomial =
+                Poly::try_convert_from(&monomial, ciphertext_ctx, Representation::PowerBasis)?;
             monomial.change_representation(Representation::NttShoup);
             ek.monomials.push(monomial);
         }
@@ -406,13 +401,8 @@ impl TryConvertFrom<&EvaluationKeyProto> for EvaluationKey {
         for l in 0..par.degree().ilog2() {
             let mut monomial = vec![0i64; par.degree()];
             monomial[par.degree() - (1 << l)] = -1;
-            let mut monomial = Poly::try_convert_from(
-                &monomial,
-                ciphertext_ctx,
-                true,
-                Representation::PowerBasis,
-            )?;
-            unsafe { monomial.allow_variable_time_computations() }
+            let mut monomial =
+                Poly::try_convert_from(&monomial, ciphertext_ctx, Representation::PowerBasis)?;
             monomial.change_representation(Representation::NttShoup);
             monomials.push(monomial);
         }

--- a/crates/fhe/src/bfv/keys/galois_key.rs
+++ b/crates/fhe/src/bfv/keys/galois_key.rs
@@ -40,7 +40,6 @@ impl GaloisKey {
         let s = Zeroizing::new(Poly::try_convert_from(
             sk.coeffs.as_ref(),
             ctx_ciphertext,
-            false,
             Representation::PowerBasis,
         )?);
         let s_sub = Zeroizing::new(s.substitute(&ciphertext_exponent)?);

--- a/crates/fhe/src/bfv/keys/relinearization_key.rs
+++ b/crates/fhe/src/bfv/keys/relinearization_key.rs
@@ -58,7 +58,6 @@ impl RelinearizationKey {
         let mut s = Zeroizing::new(Poly::try_convert_from(
             sk.coeffs.as_ref(),
             ctx_ciphertext,
-            false,
             Representation::PowerBasis,
         )?);
         s.change_representation(Representation::Ntt);
@@ -171,13 +170,9 @@ mod tests {
                 let rk = RelinearizationKey::new(&sk, &mut rng)?;
 
                 let ctx = params.ctx_at_level(0)?;
-                let mut s = Poly::try_convert_from(
-                    sk.coeffs.as_ref(),
-                    ctx,
-                    false,
-                    Representation::PowerBasis,
-                )
-                .map_err(crate::Error::MathError)?;
+                let mut s =
+                    Poly::try_convert_from(sk.coeffs.as_ref(), ctx, Representation::PowerBasis)
+                        .map_err(crate::Error::MathError)?;
                 s.change_representation(Representation::Ntt);
                 let s2 = &s * &s;
 
@@ -235,7 +230,6 @@ mod tests {
                         let mut s = Poly::try_convert_from(
                             sk.coeffs.as_ref(),
                             ctx,
-                            false,
                             Representation::PowerBasis,
                         )
                         .map_err(crate::Error::MathError)?;

--- a/crates/fhe/src/bfv/ops/dot_product.rs
+++ b/crates/fhe/src/bfv/ops/dot_product.rs
@@ -134,15 +134,10 @@ where
                 ctx.moduli_operators()
             ) {
                 for (outij_coeff, accij_coeff) in izip!(outij.iter_mut(), accij.iter()) {
-                    unsafe { *outij_coeff = q.reduce_u128_vt(*accij_coeff) }
+                    *outij_coeff = q.reduce_u128(*accij_coeff)
                 }
             }
-            c.push(Poly::try_convert_from(
-                coeffs,
-                ctx,
-                true,
-                Representation::Ntt,
-            )?)
+            c.push(Poly::try_convert_from(coeffs, ctx, Representation::Ntt)?)
         }
 
         Ok(Ciphertext {

--- a/crates/fhe/src/bfv/parameters.rs
+++ b/crates/fhe/src/bfv/parameters.rs
@@ -158,27 +158,27 @@ impl BfvParameters {
                 0x1ffffffe48001,
             ],
         );
-        n_and_qs.insert(
-            32768,
-            vec![
-                0x7fffffffe90001,
-                0x7fffffffbf0001,
-                0x7fffffffbd0001,
-                0x7fffffffba0001,
-                0x7fffffffaa0001,
-                0x7fffffffa50001,
-                0x7fffffff9f0001,
-                0x7fffffff7e0001,
-                0x7fffffff770001,
-                0x7fffffff380001,
-                0x7fffffff330001,
-                0x7fffffff2d0001,
-                0x7fffffff170001,
-                0x7fffffff150001,
-                0x7ffffffef00001,
-                0xfffffffff70001,
-            ],
-        );
+        // n_and_qs.insert(
+        //     32768,
+        //     vec![
+        //         0x7fffffffe90001,
+        //         0x7fffffffbf0001,
+        //         0x7fffffffbd0001,
+        //         0x7fffffffba0001,
+        //         0x7fffffffaa0001,
+        //         0x7fffffffa50001,
+        //         0x7fffffff9f0001,
+        //         0x7fffffff7e0001,
+        //         0x7fffffff770001,
+        //         0x7fffffff380001,
+        //         0x7fffffff330001,
+        //         0x7fffffff2d0001,
+        //         0x7fffffff170001,
+        //         0x7fffffff150001,
+        //         0x7ffffffef00001,
+        //         0xfffffffff70001,
+        //     ],
+        // );
 
         let mut params = vec![];
 
@@ -384,7 +384,6 @@ impl BfvParametersBuilder {
             let mut p = Poly::try_convert_from(
                 &[rns.lift((&delta_rests).into())],
                 &ctx_i,
-                true,
                 Representation::PowerBasis,
             )?;
             p.change_representation(Representation::NttShoup);

--- a/crates/fhe/src/bfv/plaintext.rs
+++ b/crates/fhe/src/bfv/plaintext.rs
@@ -50,8 +50,7 @@ impl Plaintext {
             .plaintext
             .scalar_mul_vec(&mut m_v, self.par.q_mod_t[self.level]);
         let ctx = self.par.ctx_at_level(self.level).unwrap();
-        let mut m =
-            Poly::try_convert_from(m_v.as_ref(), ctx, false, Representation::PowerBasis).unwrap();
+        let mut m = Poly::try_convert_from(m_v.as_ref(), ctx, Representation::PowerBasis).unwrap();
         m.change_representation(Representation::Ntt);
         m *= &self.par.delta[self.level];
         m
@@ -95,12 +94,7 @@ impl PartialEq for Plaintext {
 
 // Conversions.
 impl TryConvertFrom<&Plaintext> for Poly {
-    fn try_convert_from<R>(
-        pt: &Plaintext,
-        ctx: &Arc<Context>,
-        variable_time: bool,
-        _: R,
-    ) -> fhe_math::Result<Self>
+    fn try_convert_from<R>(pt: &Plaintext, ctx: &Arc<Context>, _: R) -> fhe_math::Result<Self>
     where
         R: Into<Option<Representation>>,
     {
@@ -114,12 +108,7 @@ impl TryConvertFrom<&Plaintext> for Poly {
                 "Incompatible contexts".to_string(),
             ))
         } else {
-            Poly::try_convert_from(
-                pt.value.as_ref(),
-                ctx,
-                variable_time,
-                Representation::PowerBasis,
-            )
+            Poly::try_convert_from(pt.value.as_ref(), ctx, Representation::PowerBasis)
         }
     }
 }

--- a/crates/fhe/src/bfv/rgsw_ciphertext.rs
+++ b/crates/fhe/src/bfv/rgsw_ciphertext.rs
@@ -92,7 +92,6 @@ impl FheEncrypter<Plaintext, RGSWCiphertext> for SecretKey {
         let mut m_s = Zeroizing::new(Poly::try_convert_from(
             self.coeffs.as_ref(),
             ctx,
-            false,
             Representation::PowerBasis,
         )?);
         m_s.change_representation(Representation::Ntt);

--- a/crates/fhe/src/mbfv/public_key_gen.rs
+++ b/crates/fhe/src/mbfv/public_key_gen.rs
@@ -42,7 +42,6 @@ impl PublicKeyShare {
         let mut s = Zeroizing::new(Poly::try_convert_from(
             sk_share.coeffs.as_ref(),
             ctx,
-            false,
             Representation::PowerBasis,
         )?);
         s.change_representation(Representation::Ntt);
@@ -51,11 +50,9 @@ impl PublicKeyShare {
         let e = Zeroizing::new(Poly::small(ctx, Representation::Ntt, par.variance, rng)?);
         // Create p0_i share
         let mut p0_share = -crp.poly.clone();
-        p0_share.disallow_variable_time_computations();
         p0_share.change_representation(Representation::Ntt);
         p0_share *= s.as_ref();
         p0_share += e.as_ref();
-        unsafe { p0_share.allow_variable_time_computations() }
 
         Ok(Self { par, crp, p0_share })
     }

--- a/crates/fhe/src/mbfv/public_key_switch.rs
+++ b/crates/fhe/src/mbfv/public_key_switch.rs
@@ -53,11 +53,9 @@ impl PublicKeySwitchShare {
         let mut s = Zeroizing::new(Poly::try_convert_from(
             sk_share.coeffs.as_ref(),
             ctx,
-            false,
             Representation::PowerBasis,
         )?);
         s.change_representation(Representation::Ntt);
-        s.disallow_variable_time_computations();
 
         let u = Zeroizing::new(Poly::small(ctx, Representation::Ntt, par.variance, rng)?);
         // TODO this should be exponential in ciphertext noise!
@@ -65,21 +63,14 @@ impl PublicKeySwitchShare {
         let e1 = Zeroizing::new(Poly::small(ctx, Representation::Ntt, par.variance, rng)?);
 
         let mut h0 = pk_ct.c[0].clone();
-        h0.disallow_variable_time_computations();
         h0 *= u.as_ref();
         *s.as_mut() *= &ct.c[1];
         h0 += s.as_ref();
         h0 += e0.as_ref();
 
         let mut h1 = pk_ct.c[1].clone();
-        h1.disallow_variable_time_computations();
         h1 *= u.as_ref();
         h1 += e1.as_ref();
-
-        unsafe {
-            h0.allow_variable_time_computations();
-            h1.allow_variable_time_computations();
-        }
 
         Ok(Self {
             par,

--- a/crates/fhe/src/mbfv/relin_key_gen.rs
+++ b/crates/fhe/src/mbfv/relin_key_gen.rs
@@ -150,7 +150,6 @@ impl RelinKeyShare<R1> {
         let s = Zeroizing::new(Poly::try_convert_from(
             sk_share.coeffs.as_ref(),
             ctx,
-            false,
             Representation::PowerBasis,
         )?);
         let rns = RnsContext::new(&sk_share.par.moduli[..crp.len()])?;
@@ -165,7 +164,6 @@ impl RelinKeyShare<R1> {
                 let e = Zeroizing::new(Poly::small(ctx, Representation::Ntt, par.variance, rng)?);
 
                 let mut h = -a.poly.clone();
-                h.disallow_variable_time_computations();
                 h.change_representation(Representation::Ntt);
                 h *= u.as_ref();
                 h += w_s.as_ref();
@@ -186,7 +184,6 @@ impl RelinKeyShare<R1> {
         let mut s = Zeroizing::new(Poly::try_convert_from(
             sk_share.coeffs.as_ref(),
             ctx,
-            false,
             Representation::PowerBasis,
         )?);
         s.change_representation(Representation::Ntt);
@@ -195,7 +192,6 @@ impl RelinKeyShare<R1> {
             .iter()
             .map(|a| {
                 let mut h = a.poly.clone();
-                h.disallow_variable_time_computations();
                 h.change_representation(Representation::Ntt);
                 let e = Zeroizing::new(Poly::small(ctx, Representation::Ntt, par.variance, rng)?);
                 h *= s.as_ref();
@@ -261,7 +257,6 @@ impl RelinKeyShare<R2> {
         let mut s = Zeroizing::new(Poly::try_convert_from(
             sk_share.coeffs.as_ref(),
             ctx,
-            false,
             Representation::PowerBasis,
         )?);
         s.change_representation(Representation::Ntt);
@@ -271,7 +266,6 @@ impl RelinKeyShare<R2> {
                 let e = Zeroizing::new(Poly::small(ctx, Representation::Ntt, par.variance, rng)?);
 
                 let mut h_prime = h.clone();
-                h_prime.disallow_variable_time_computations();
                 h_prime.change_representation(Representation::Ntt);
                 h_prime *= s.as_ref();
 
@@ -293,7 +287,6 @@ impl RelinKeyShare<R2> {
         let mut s = Zeroizing::new(Poly::try_convert_from(
             sk_share.coeffs.as_ref(),
             ctx,
-            false,
             Representation::PowerBasis,
         )?);
         s.change_representation(Representation::Ntt);
@@ -304,7 +297,6 @@ impl RelinKeyShare<R2> {
             .iter()
             .map(|h| {
                 let mut h_prime = h.clone();
-                h_prime.disallow_variable_time_computations();
                 h_prime.change_representation(Representation::Ntt);
                 let e = Zeroizing::new(Poly::small(ctx, Representation::Ntt, par.variance, rng)?);
                 h_prime *= u_s.as_ref();

--- a/crates/fhe/src/mbfv/secret_key_switch.rs
+++ b/crates/fhe/src/mbfv/secret_key_switch.rs
@@ -57,14 +57,12 @@ impl SecretKeySwitchShare {
         let mut s_in = Zeroizing::new(Poly::try_convert_from(
             sk_input_share.coeffs.as_ref(),
             ct.c[0].ctx(),
-            false,
             Representation::PowerBasis,
         )?);
         s_in.change_representation(Representation::Ntt);
         let mut s_out = Zeroizing::new(Poly::try_convert_from(
             sk_output_share.coeffs.as_ref(),
             ct.c[0].ctx(),
-            false,
             Representation::PowerBasis,
         )?);
         s_out.change_representation(Representation::Ntt);
@@ -80,7 +78,6 @@ impl SecretKeySwitchShare {
 
         // Create h_i share
         let mut h_share = s_in.as_ref() - s_out.as_ref();
-        h_share.disallow_variable_time_computations();
         h_share *= &ct.c[1];
         h_share += e.as_ref();
 
@@ -146,7 +143,6 @@ impl Aggregate<DecryptionShare> for Plaintext {
 
         // Note: during SKS, c[1]*sk has already been added to c[0].
         let mut c = Zeroizing::new(ct.c[0].clone());
-        c.disallow_variable_time_computations();
         c.change_representation(Representation::PowerBasis);
 
         // The true decryption part is done during SKS; all that is left is to scale
@@ -162,8 +158,7 @@ impl Aggregate<DecryptionShare> for Plaintext {
         q.reduce_vec(&mut w);
         par.plaintext.reduce_vec(&mut w);
 
-        let mut poly =
-            Poly::try_convert_from(&w, ct.c[0].ctx(), false, Representation::PowerBasis)?;
+        let mut poly = Poly::try_convert_from(&w, ct.c[0].ctx(), Representation::PowerBasis)?;
         poly.change_representation(Representation::Ntt);
 
         let pt = Plaintext {


### PR DESCRIPTION
It seems that after #238 , there is no more advantage of doing variable time computations, even on Apple M1/M2(!). This PR would remove all the "variable time" consideration from all the crates.

**It requires full benchmarking on multiple platforms before merge.**