### PR TITLE
Migrate to tfhe-ntt for NTT operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,12 @@ dependencies = [
 
 [[package]]
 name = "aligned-vec"
-version = "0.5.0"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4aa90d7ce82d4be67b64039a3d588d38dbcc6736577de4a847025ce5b0c468d1"
+checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
+dependencies = [
+ "equator",
+]
 
 [[package]]
 name = "anes"
@@ -127,9 +130,9 @@ checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "bytemuck"
-version = "1.14.1"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2490600f404f2b94c167e31d3ed1d5f3c225a0f3b80230053b3e0b7b962bd9"
+checksum = "3995eaeebcdf32f91f980d360f78732ddc061097ab4e39991ae7a6ace9194677"
 
 [[package]]
 name = "byteorder"
@@ -213,7 +216,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -227,16 +230,6 @@ name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
-
-[[package]]
-name = "concrete-ntt"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4f4643dbd5de069e099122ae6c2bbd3db70d69ffec348dfc228448d635f949e"
-dependencies = [
- "aligned-vec",
- "pulp",
-]
 
 [[package]]
 name = "console"
@@ -402,6 +395,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "equator"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -466,7 +479,6 @@ dependencies = [
 name = "fhe-math"
 version = "0.1.0-beta.8"
 dependencies = [
- "concrete-ntt",
  "criterion",
  "derivative",
  "ethnum",
@@ -477,6 +489,7 @@ dependencies = [
  "ndarray",
  "num-bigint",
  "num-bigint-dig",
+ "num-complex",
  "num-traits",
  "proptest",
  "prost",
@@ -485,6 +498,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "sha2",
+ "tfhe-ntt",
  "thiserror",
  "zeroize",
  "zeroize_derive",
@@ -778,9 +792,9 @@ dependencies = [
 
 [[package]]
 name = "num-complex"
-version = "0.4.4"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ba157ca0885411de85d6ca030ba7e2a83a28636056c7c699b07c8b6f7383214"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
  "bytemuck",
  "num-traits",
@@ -892,14 +906,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
 dependencies = [
  "proc-macro2",
- "syn 2.0.46",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.74"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2de98502f212cfcea8d0bb305bd0f49d7ebdd75b64ba0a68f937d888f4e0d6db"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
@@ -951,7 +965,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.46",
+ "syn 2.0.106",
  "tempfile",
  "which",
 ]
@@ -966,7 +980,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -980,14 +994,16 @@ dependencies = [
 
 [[package]]
 name = "pulp"
-version = "0.18.9"
+version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03457ac216146f43f921500bac4e892d5cd32b0479b929cbfc90f95cd6c599c2"
+checksum = "96b86df24f0a7ddd5e4b95c94fc9ed8a98f1ca94d3b01bdce2824097e7835907"
 dependencies = [
  "bytemuck",
+ "cfg-if",
  "libm",
  "num-complex",
  "reborrow",
+ "version_check",
 ]
 
 [[package]]
@@ -998,9 +1014,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -1177,7 +1193,7 @@ checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1233,9 +1249,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.46"
+version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89456b690ff72fddcecf231caedbe615c59480c93358a93dfae7fc29e3ebbf0e"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1256,6 +1272,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tfhe-ntt"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c64925e25d6ba666f75332ce44fbd2e80be64dbd657e3c2652a6a07f2868d17"
+dependencies = [
+ "aligned-vec",
+ "bytemuck",
+ "pulp",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1272,7 +1299,7 @@ checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1317,9 +1344,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wait-timeout"
@@ -1367,7 +1394,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.106",
  "wasm-bindgen-shared",
 ]
 
@@ -1389,7 +1416,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.106",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1599,5 +1626,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.106",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.73"
 
 [workspace.dependencies]
 clap = { version = "^4.5.4", features = ["derive"] }
-concrete-ntt = "^0.1.2"
+tfhe-ntt = "^0.6.0"
 console = "^0.15.8"
 criterion = "^0.5.1"
 doc-comment = "^0.3.3"
@@ -28,12 +28,15 @@ ndarray = "^0.15.6"
 num-bigint = "^0.4.4"
 num-bigint-dig = "^0.8.4"
 num-traits = "^0.2.18"
+num-complex = { version = "^0.4.6", features = ["libm"] }
 proptest = "^1.4.0"
 prost = "^0.12.4"
 prost-build = "^0.12.3"
+pulp = "^0.21.5"
 rand = "^0.8.5"
 rand_chacha = "^0.3.1"
 sha2 = "^0.10.8"
 thiserror = "^1.0.58"
 zeroize = "^1.8.0"
 zeroize_derive = "^1.4.2"
+

--- a/crates/fhe-math/Cargo.toml
+++ b/crates/fhe-math/Cargo.toml
@@ -13,14 +13,14 @@ rust-version.workspace = true
 bench = false  # Disable default bench (we use criterion)
 
 [features]
-concrete-ntt = []
-concrete-ntt-nightly = ["concrete-ntt/nightly"]
+tfhe-ntt = []
+tfhe-ntt-nightly = ["tfhe-ntt/nightly"]
 
 [dependencies]
 fhe-traits = { version = "^0.1.0-beta.8", path = "../fhe-traits" }
 fhe-util = { version = "^0.1.0-beta.8", path = "../fhe-util" }
 
-concrete-ntt.workspace = true
+tfhe-ntt.workspace = true
 derivative = "^2.2.0"
 ethnum.workspace = true
 fastdiv.workspace = true
@@ -30,13 +30,14 @@ num-bigint.workspace = true
 num-bigint-dig.workspace = true
 num-traits.workspace = true
 prost.workspace = true
-pulp = "^0.18.9"
+pulp.workspace = true
 rand.workspace = true
 rand_chacha.workspace = true
 thiserror.workspace = true
 zeroize.workspace = true
 zeroize_derive.workspace = true
 sha2.workspace = true
+num-complex.workspace = true
 
 [build-dependencies]
 prost-build.workspace = true

--- a/crates/fhe-math/src/ntt/mod.rs
+++ b/crates/fhe-math/src/ntt/mod.rs
@@ -4,13 +4,13 @@ use fhe_util::is_prime;
 
 mod native;
 
-#[cfg(any(feature = "concrete-ntt", feature = "concrete-ntt-nightly"))]
-mod concrete;
+#[cfg(any(feature = "tfhe-ntt", feature = "tfhe-ntt-nightly"))]
+mod tfhe;
 
-#[cfg(any(feature = "concrete-ntt", feature = "concrete-ntt-nightly"))]
-pub use concrete::NttOperator;
-#[cfg(not(any(feature = "concrete-ntt", feature = "concrete-ntt-nightly")))]
+#[cfg(not(any(feature = "tfhe-ntt", feature = "tfhe-ntt-nightly")))]
 pub use native::NttOperator;
+#[cfg(any(feature = "tfhe-ntt", feature = "tfhe-ntt-nightly"))]
+pub use tfhe::NttOperator;
 
 /// Returns whether a modulus p is prime and supports the Number Theoretic
 /// Transform of size n.

--- a/crates/fhe-math/src/ntt/tfhe.rs
+++ b/crates/fhe-math/src/ntt/tfhe.rs
@@ -1,4 +1,4 @@
-use concrete_ntt::prime64::Plan;
+use tfhe_ntt::prime64::Plan;
 
 use crate::zq::Modulus;
 
@@ -7,7 +7,7 @@ use super::native;
 /// Number-Theoretic Transform operator.
 #[derive(Debug, Clone)]
 pub struct NttOperator {
-    concrete_operator: Option<Plan>,
+    tfhe_operator: Option<Plan>,
     native_operator: native::NttOperator,
 }
 
@@ -27,9 +27,9 @@ impl NttOperator {
     /// size.
     pub fn new(p: &Modulus, size: usize) -> Option<Self> {
         let native_operator = native::NttOperator::new(p, size)?;
-        let concrete_operator = Plan::try_new(size, p.p);
+        let tfhe_operator = Plan::try_new(size, p.p);
         Some(Self {
-            concrete_operator,
+            tfhe_operator,
             native_operator,
         })
     }
@@ -37,8 +37,8 @@ impl NttOperator {
     /// Compute the forward NTT in place.
     /// Aborts if a is not of the size handled by the operator.
     pub fn forward(&self, a: &mut [u64]) {
-        if let Some(ref concrete_operator) = self.concrete_operator {
-            concrete_operator.fwd(a);
+        if let Some(ref tfhe_operator) = self.tfhe_operator {
+            tfhe_operator.fwd(a);
         } else {
             self.native_operator.forward(a);
         }
@@ -47,9 +47,9 @@ impl NttOperator {
     /// Compute the backward NTT in place.
     /// Aborts if a is not of the size handled by the operator.
     pub fn backward(&self, a: &mut [u64]) {
-        if let Some(ref concrete_operator) = self.concrete_operator {
-            concrete_operator.inv(a);
-            concrete_operator.normalize(a);
+        if let Some(ref tfhe_operator) = self.tfhe_operator {
+            tfhe_operator.inv(a);
+            tfhe_operator.normalize(a);
         } else {
             self.native_operator.backward(a);
         }
@@ -64,9 +64,9 @@ impl NttOperator {
     /// This function is not constant time and its timing may reveal information
     /// about the value being reduced.
     pub(crate) unsafe fn forward_vt_lazy(&self, a_ptr: *mut u64) {
-        if let Some(ref concrete_operator) = self.concrete_operator {
-            let a = std::slice::from_raw_parts_mut(a_ptr, concrete_operator.ntt_size());
-            concrete_operator.fwd(a);
+        if let Some(ref tfhe_operator) = self.tfhe_operator {
+            let a = std::slice::from_raw_parts_mut(a_ptr, tfhe_operator.ntt_size());
+            tfhe_operator.fwd(a);
         } else {
             self.native_operator.forward_vt_lazy(a_ptr);
         }
@@ -79,9 +79,9 @@ impl NttOperator {
     /// This function is not constant time and its timing may reveal information
     /// about the value being reduced.
     pub unsafe fn forward_vt(&self, a_ptr: *mut u64) {
-        if let Some(ref concrete_operator) = self.concrete_operator {
-            let a = std::slice::from_raw_parts_mut(a_ptr, concrete_operator.ntt_size());
-            concrete_operator.fwd(a);
+        if let Some(ref tfhe_operator) = self.tfhe_operator {
+            let a = std::slice::from_raw_parts_mut(a_ptr, tfhe_operator.ntt_size());
+            tfhe_operator.fwd(a);
         } else {
             self.native_operator.forward_vt(a_ptr);
         }
@@ -94,10 +94,10 @@ impl NttOperator {
     /// This function is not constant time and its timing may reveal information
     /// about the value being reduced.
     pub unsafe fn backward_vt(&self, a_ptr: *mut u64) {
-        if let Some(ref concrete_operator) = self.concrete_operator {
-            let a = std::slice::from_raw_parts_mut(a_ptr, concrete_operator.ntt_size());
-            concrete_operator.inv(a);
-            concrete_operator.normalize(a);
+        if let Some(ref tfhe_operator) = self.tfhe_operator {
+            let a = std::slice::from_raw_parts_mut(a_ptr, tfhe_operator.ntt_size());
+            tfhe_operator.inv(a);
+            tfhe_operator.normalize(a);
         } else {
             self.native_operator.backward_vt(a_ptr);
         }

--- a/crates/fhe/Cargo.toml
+++ b/crates/fhe/Cargo.toml
@@ -13,8 +13,8 @@ rust-version.workspace = true
 bench = false # Disable default bench (we use criterion)
 
 [features]
-concrete-ntt = ["fhe-math/concrete-ntt"]
-concrete-ntt-nightly = ["fhe-math/concrete-ntt-nightly"]
+tfhe-ntt = ["fhe-math/tfhe-ntt"]
+tfhe-ntt-nightly = ["fhe-math/tfhe-ntt-nightly"]
 
 [dependencies]
 fhe-math = { version = "^0.1.0-beta.8", path = "../fhe-math" }


### PR DESCRIPTION
## Summary
- Replace `concrete-ntt` with `tfhe-ntt` v0.6.0
- Update NTT module and features to use the new crate
- Consolidate `pulp` dependency at the workspace level and remove the `num-complex` patch

## Testing
- `cargo test`
- `cargo +nightly fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_68a928799bac832386c0510989b92dd0