### PR TITLE
docs: add crate readmes

### DIFF
--- a/crates/fhe-math/README.md
+++ b/crates/fhe-math/README.md
@@ -1,0 +1,34 @@
+# fhe-math [![crate version](https://img.shields.io/crates/v/fhe-math.svg)](https://crates.io/crates/fhe-math) [![documentation](https://docs.rs/fhe-math/badge.svg)](https://docs.rs/fhe-math)
+
+Core mathematical primitives for the [`fhe.rs`](https://github.com/tlepoint/fhe.rs) ecosystem.
+
+This crate exposes building blocks such as number theoretic transforms (NTT), residue number system (RNS) arithmetic, and ring arithmetic over `Z_q` that are used by higher level crates like [`fhe`](https://crates.io/crates/fhe).
+
+## Features
+
+* `ntt`, `rns`, `rq`, and `zq` modules for modular arithmetic over large rings.
+* Optional `tfhe-ntt` and `tfhe-ntt-nightly` features to enable hardware accelerated NTTs via the [`tfhe-ntt`](https://crates.io/crates/tfhe-ntt) crate.
+
+## Installation
+
+Add the following to your `Cargo.toml`:
+
+```toml
+[dependencies]
+fhe-math = "0.1.0-beta.8"
+```
+
+## Testing
+
+```bash
+cargo test -p fhe-math
+```
+
+## License
+
+This project is licensed under the [MIT license](https://opensource.org/licenses/MIT).
+
+## Security / Stability
+
+The code in this crate has not undergone an independent security audit and the API may change before version `1.0.0`.
+Use at your own risk.

--- a/crates/fhe-traits/README.md
+++ b/crates/fhe-traits/README.md
@@ -1,0 +1,27 @@
+# fhe-traits [![crate version](https://img.shields.io/crates/v/fhe-traits.svg)](https://crates.io/crates/fhe-traits) [![documentation](https://docs.rs/fhe-traits/badge.svg)](https://docs.rs/fhe-traits)
+
+Traits defining the interface for fully homomorphic encryption types and operations.
+
+This crate provides common abstractions for parameters, plaintext and ciphertext representations, encoding, encryption, decryption and serialization used throughout the [`fhe.rs`](https://github.com/tlepoint/fhe.rs) crates.
+
+## Installation
+
+```toml
+[dependencies]
+fhe-traits = "0.1.0-beta.8"
+```
+
+## Testing
+
+```bash
+cargo test -p fhe-traits
+```
+
+## License
+
+This project is licensed under the [MIT license](https://opensource.org/licenses/MIT).
+
+## Security / Stability
+
+The code in this crate has not undergone an independent security audit and the API may change before version `1.0.0`.
+Use at your own risk.

--- a/crates/fhe-util/README.md
+++ b/crates/fhe-util/README.md
@@ -1,0 +1,27 @@
+# fhe-util [![crate version](https://img.shields.io/crates/v/fhe-util.svg)](https://crates.io/crates/fhe-util) [![documentation](https://docs.rs/fhe-util/badge.svg)](https://docs.rs/fhe-util)
+
+Utility functions for the [`fhe.rs`](https://github.com/tlepoint/fhe.rs) ecosystem.
+
+The crate contains helper routines such as primality testing, centered binomial sampling, modular arithmetic helpers and other small utilities relied upon by the [`fhe`](https://crates.io/crates/fhe) and `fhe-math` crates.
+
+## Installation
+
+```toml
+[dependencies]
+fhe-util = "0.1.0-beta.8"
+```
+
+## Testing
+
+```bash
+cargo test -p fhe-util
+```
+
+## License
+
+This project is licensed under the [MIT license](https://opensource.org/licenses/MIT).
+
+## Security / Stability
+
+The code in this crate has not undergone an independent security audit and the API may change before version `1.0.0`.
+Use at your own risk.

--- a/crates/fhe/README.md
+++ b/crates/fhe/README.md
@@ -1,4 +1,4 @@
-# fhe [![fhe crate version](https://img.shields.io/crates/v/fhe.svg)](https://crates.io/crates/fhe)
+# fhe [![fhe crate version](https://img.shields.io/crates/v/fhe.svg)](https://crates.io/crates/fhe) [![documentation](https://docs.rs/fhe/badge.svg)](https://docs.rs/fhe)
 
 **A pure-Rust implementation of fully homomorphic encryption schemes based on Ring-LWE.**
 
@@ -8,6 +8,15 @@ This library provides implementations of:
 
 * BFV, the Brakerski-Fan-Vercauteren (BFV) homomorphic encryption scheme.
   More precisely, this library implements a leveled variant of the [HPS](https://eprint.iacr.org/2018/117) (Halevi--Polyakov--Shoup) RNS-variant of the scheme.
+
+## Installation
+
+Add the following to your `Cargo.toml`:
+
+```toml
+[dependencies]
+fhe = "0.1.0-beta.8"
+```
 
 ## Example
 


### PR DESCRIPTION
## Summary
- add READMEs for `fhe-math`, `fhe-traits`, and `fhe-util`
- link docs.rs and installation instructions in the `fhe` crate README

## Testing
- `cargo test -p fhe-util`
- `cargo test -p fhe-traits`
- `cargo test -p fhe-math`
- `cargo test -p fhe`


------
https://chatgpt.com/codex/tasks/task_e_68aa341fb8e483239a6eae72263cf002