### PR TITLE
Introduce linked context chain for BFV modulus switching

### DIFF
--- a/crates/fhe/src/bfv/context_chain.rs
+++ b/crates/fhe/src/bfv/context_chain.rs
@@ -1,0 +1,113 @@
+use std::sync::{Arc, Weak};
+
+use fhe_math::{
+    rns::ScalingFactor,
+    rq::{scaler::Scaler, Context},
+};
+
+use crate::bfv::context::CipherPlainContext;
+
+/// A context in the modulus switching chain
+#[derive(Debug, Clone)]
+pub struct ContextLevel {
+    /// The polynomial context at this level
+    pub poly_context: Arc<Context>,
+    /// Bridge to plaintext operations
+    pub cipher_plain_context: Arc<CipherPlainContext>,
+    /// Level number (0 = highest, increases as we switch down)
+    pub level: usize,
+    /// Total number of moduli at this level
+    pub num_moduli: usize,
+    /// Next level in the chain (fewer moduli)
+    pub next: Option<Arc<ContextLevel>>,
+    /// Previous level in the chain (more moduli)
+    pub prev: Option<Weak<ContextLevel>>,
+    /// Modulus switching scaler to next level
+    pub down_scaler: Option<Arc<Scaler>>,
+    /// Modulus switching scaler from previous level
+    pub up_scaler: Option<Arc<Scaler>>,
+}
+
+impl PartialEq for ContextLevel {
+    fn eq(&self, other: &Self) -> bool {
+        self.level == other.level
+            && self.num_moduli == other.num_moduli
+            && self.cipher_plain_context == other.cipher_plain_context
+    }
+}
+
+impl Eq for ContextLevel {}
+
+impl ContextLevel {
+    /// Create a new context level
+    pub fn new(
+        poly_context: Arc<Context>,
+        cipher_plain_context: Arc<CipherPlainContext>,
+        level: usize,
+    ) -> Self {
+        Self {
+            num_moduli: poly_context.moduli().len(),
+            poly_context,
+            cipher_plain_context,
+            level,
+            next: None,
+            prev: None,
+            down_scaler: None,
+            up_scaler: None,
+        }
+    }
+
+    /// Chain two levels together
+    pub fn chain(prev: &mut Arc<Self>, next: &mut Arc<Self>) {
+        // Create scalers for modulus switching when possible
+        if let Ok(ds) = Scaler::new(&prev.poly_context, &next.poly_context, ScalingFactor::one()) {
+            if let Some(p) = Arc::get_mut(prev) {
+                p.down_scaler = Some(Arc::new(ds));
+            }
+        }
+        if let Ok(us) = Scaler::new(&next.poly_context, &prev.poly_context, ScalingFactor::one()) {
+            if let Some(n) = Arc::get_mut(next) {
+                n.up_scaler = Some(Arc::new(us));
+            }
+        }
+        if let Some(p) = Arc::get_mut(prev) {
+            p.next = Some(next.clone());
+        }
+        if let Some(n) = Arc::get_mut(next) {
+            n.prev = Some(Arc::downgrade(prev));
+        }
+    }
+
+    /// Check if this level can switch to the next
+    pub fn can_switch_down(&self) -> bool {
+        self.next.is_some()
+    }
+
+    /// Get the maximum level reachable from this context
+    pub fn max_level(&self) -> usize {
+        let mut max = self.level;
+        let mut current = &self.next;
+        while let Some(ctx) = current {
+            max = ctx.level;
+            current = &ctx.next;
+        }
+        max
+    }
+
+    /// Walk the entire chain and collect all levels
+    pub fn collect_chain(&self) -> Vec<Arc<ContextLevel>> {
+        let mut chain = Vec::new();
+        // Move to head
+        let mut current = self.clone();
+        while let Some(prev) = current.prev.as_ref().and_then(|w| w.upgrade()) {
+            current = (*prev).clone();
+        }
+        // Collect
+        let mut cur = Some(Arc::new(current));
+        while let Some(node) = cur {
+            chain.push(node.clone());
+            cur = node.next.clone();
+        }
+        chain
+    }
+}

--- a/crates/fhe/src/bfv/level_manager.rs
+++ b/crates/fhe/src/bfv/level_manager.rs
@@ -1,0 +1,55 @@
+use std::sync::Arc;
+
+use crate::{Error, Result};
+
+use super::{context_chain::ContextLevel, Ciphertext};
+
+/// Utility struct to manage ciphertext levels automatically
+pub struct LevelManager {
+    context_chain: Arc<ContextLevel>,
+}
+
+impl LevelManager {
+    /// Create a new level manager from the head of a context chain
+    pub fn new(context_chain: Arc<ContextLevel>) -> Self {
+        Self { context_chain }
+    }
+
+    /// Determine the best level for addition
+    pub fn optimal_level_for_add(&self, a: &Ciphertext, b: &Ciphertext) -> usize {
+        a.level.max(b.level)
+    }
+
+    /// Determine the best level for multiplication
+    pub fn optimal_level_for_mul(&self, a: &Ciphertext, b: &Ciphertext) -> Result<usize> {
+        let next_level = self.optimal_level_for_add(a, b) + 1;
+        if next_level <= self.context_chain.max_level() {
+            Ok(next_level)
+        } else {
+            Err(Error::DefaultError(format!(
+                "Invalid level: {next_level}, max level: {}",
+                self.context_chain.max_level()
+            )))
+        }
+    }
+
+    /// Align two ciphertexts to the same level
+    pub fn align_levels(&self, a: &mut Ciphertext, b: &mut Ciphertext) -> Result<()> {
+        let target = self.optimal_level_for_add(a, b);
+        a.switch_to_level(target)?;
+        b.switch_to_level(target)?;
+        Ok(())
+    }
+
+    /// Align a batch of ciphertexts
+    pub fn align_batch(&self, cts: &mut [Ciphertext]) -> Result<usize> {
+        if cts.is_empty() {
+            return Ok(0);
+        }
+        let target = cts.iter().map(|c| c.level).max().unwrap();
+        for ct in cts {
+            ct.switch_to_level(target)?;
+        }
+        Ok(target)
+    }
+}

--- a/crates/fhe/src/bfv/mod.rs
+++ b/crates/fhe/src/bfv/mod.rs
@@ -4,8 +4,10 @@
 
 mod ciphertext;
 mod context;
+mod context_chain;
 mod encoding;
 mod keys;
+mod level_manager;
 mod ops;
 mod parameters;
 mod plaintext;
@@ -15,9 +17,11 @@ mod rgsw_ciphertext;
 pub mod traits;
 pub use ciphertext::Ciphertext;
 pub use context::CipherPlainContext;
+pub use context_chain::ContextLevel;
 pub use encoding::Encoding;
 pub(crate) use keys::KeySwitchingKey;
 pub use keys::{EvaluationKey, EvaluationKeyBuilder, PublicKey, RelinearizationKey, SecretKey};
+pub use level_manager::LevelManager;
 pub use ops::{dot_product_scalar, Multiplicator};
 pub use parameters::{BfvParameters, BfvParametersBuilder};
 pub use plaintext::Plaintext;


### PR DESCRIPTION
## Summary
- add `ContextLevel` linked structure for modulus switching
- expose context chain in `BfvParameters` and chain-aware ciphertext helpers
- provide `LevelManager` utilities for aligning ciphertext levels

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ab4fcb7b8c8323abb670f2fe535022