### PR TITLE
[agent] Optimize ciphertext operations

### DIFF
--- a/crates/fhe/src/bfv/keys/secret_key.rs
+++ b/crates/fhe/src/bfv/keys/secret_key.rs
@@ -141,7 +141,7 @@ impl FheEncrypter<Plaintext, Ciphertext> for SecretKey {
         pt: &Plaintext,
         rng: &mut R,
     ) -> Result<Ciphertext> {
-        assert_eq!(self.par, pt.par);
+        assert!(Arc::ptr_eq(&self.par, &pt.par));
         let m = Zeroizing::new(pt.to_poly());
         self.encrypt_poly(m.as_ref(), rng)
     }
@@ -151,7 +151,7 @@ impl FheDecrypter<Plaintext, Ciphertext> for SecretKey {
     type Error = Error;
 
     fn try_decrypt(&self, ct: &Ciphertext) -> Result<Plaintext> {
-        if self.par != ct.par {
+        if !Arc::ptr_eq(&self.par, &ct.par) {
             Err(Error::DefaultError(
                 "Incompatible BFV parameters".to_string(),
             ))


### PR DESCRIPTION
## Summary
- refactor ciphertext arithmetic to operate on owned types using iterator `zip`
- compare parameter arcs with `Arc::ptr_eq` to avoid deep struct equality checks

## Testing
- `cargo +nightly fmt --all`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_68ab84050da48323a2fc3fa1acb5db3d