### PR TITLE
[agent] Mark enums non-exhaustive and return iterators

### DIFF
--- a/crates/fhe-math/src/errors.rs
+++ b/crates/fhe-math/src/errors.rs
@@ -7,6 +7,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 
 /// Enum encapsulation all the possible errors from this library.
 #[derive(Debug, Error, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum Error {
     /// Indicates an invalid modulus
     #[error("Invalid modulus: modulus {0} should be between 2 and (1 << 62) - 1.")]

--- a/crates/fhe-math/src/proto/rq.rs
+++ b/crates/fhe-math/src/proto/rq.rs
@@ -14,6 +14,7 @@ pub struct Rq {
 }
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
+#[non_exhaustive]
 pub enum Representation {
     Unknown = 0,
     Powerbasis = 1,

--- a/crates/fhe-math/src/rq/mod.rs
+++ b/crates/fhe-math/src/rq/mod.rs
@@ -26,6 +26,7 @@ use zeroize::{Zeroize, Zeroizing};
 
 /// Possible representations of the underlying polynomial.
 #[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum Representation {
     /// This is the list of coefficients ci, such that the polynomial is c0 + c1
     /// * x + ... + c_(degree - 1) * x^(degree - 1)

--- a/crates/fhe/benches/bfv_optimized_ops.rs
+++ b/crates/fhe/benches/bfv_optimized_ops.rs
@@ -12,24 +12,25 @@ pub fn bfv_benchmark(c: &mut Criterion) {
     group.warm_up_time(Duration::from_secs(1));
     group.measurement_time(Duration::from_secs(1));
 
-    for par in &BfvParameters::default_parameters_128(20)[2..] {
+    for par in BfvParameters::default_parameters_128(20).skip(2) {
         for size in [10, 128, 1000] {
-            let sk = SecretKey::random(par, &mut OsRng);
+            let sk = SecretKey::random(&par, &mut OsRng);
             let pt1 =
-                Plaintext::try_encode(&(1..16u64).collect_vec(), Encoding::poly(), par).unwrap();
+                Plaintext::try_encode(&(1..16u64).collect_vec(), Encoding::poly(), &par).unwrap();
             let mut c1: Ciphertext = sk.try_encrypt(&pt1, &mut rng).unwrap();
 
             let ct_vec = (0..size)
                 .map(|i| {
                     let pt =
-                        Plaintext::try_encode(&(i..16u64).collect_vec(), Encoding::poly(), par)
+                        Plaintext::try_encode(&(i..16u64).collect_vec(), Encoding::poly(), &par)
                             .unwrap();
                     sk.try_encrypt(&pt, &mut rng).unwrap()
                 })
                 .collect_vec();
             let pt_vec = (0..size)
                 .map(|i| {
-                    Plaintext::try_encode(&(i..39u64).collect_vec(), Encoding::poly(), par).unwrap()
+                    Plaintext::try_encode(&(i..39u64).collect_vec(), Encoding::poly(), &par)
+                        .unwrap()
                 })
                 .collect_vec();
 

--- a/crates/fhe/benches/bfv_rgsw.rs
+++ b/crates/fhe/benches/bfv_rgsw.rs
@@ -11,12 +11,12 @@ pub fn bfv_rgsw_benchmark(c: &mut Criterion) {
     group.warm_up_time(Duration::from_secs(1));
     group.measurement_time(Duration::from_secs(1));
 
-    for par in &BfvParameters::default_parameters_128(20)[2..] {
+    for par in BfvParameters::default_parameters_128(20).skip(2) {
         let mut rng = thread_rng();
-        let sk = SecretKey::random(par, &mut OsRng);
+        let sk = SecretKey::random(&par, &mut OsRng);
 
-        let pt1 = Plaintext::try_encode(&(1..16u64).collect_vec(), Encoding::simd(), par).unwrap();
-        let pt2 = Plaintext::try_encode(&(3..39u64).collect_vec(), Encoding::simd(), par).unwrap();
+        let pt1 = Plaintext::try_encode(&(1..16u64).collect_vec(), Encoding::simd(), &par).unwrap();
+        let pt2 = Plaintext::try_encode(&(3..39u64).collect_vec(), Encoding::simd(), &par).unwrap();
         let c1: Ciphertext = sk.try_encrypt(&pt1, &mut rng).unwrap();
         let c2: RGSWCiphertext = sk.try_encrypt(&pt2, &mut rng).unwrap();
         let q = par.moduli_sizes().iter().sum::<usize>();

--- a/crates/fhe/src/errors.rs
+++ b/crates/fhe/src/errors.rs
@@ -8,6 +8,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 /// Enum encapsulating all the possible errors from this library.
 #[derive(Debug, Error, PartialEq, Eq)]
 #[allow(missing_docs)]
+#[non_exhaustive]
 pub enum Error {
     /// Indicates that an error from the underlying mathematical library was
     /// encountered.
@@ -164,6 +165,7 @@ impl Error {
 /// Separate enum for errors arising from serialization.
 #[derive(Debug, Error, PartialEq, Eq)]
 #[allow(missing_docs)]
+#[non_exhaustive]
 pub enum SerializationError {
     /// Indicates polynomial context was not found during deserialization
     #[error("Polynomial context not found: {context_id}")]
@@ -216,6 +218,7 @@ impl From<std::io::Error> for SerializationError {
 /// Separate enum to indicate parameters-related errors.
 #[derive(Debug, Error, PartialEq, Eq)]
 #[allow(missing_docs)]
+#[non_exhaustive]
 pub enum ParametersError {
     /// Indicates that the degree is invalid.
     #[error("Invalid polynomial degree {degree}: must be a power of 2 between {min} and {max}")]

--- a/crates/fhe/tests/unified_context_integration.rs
+++ b/crates/fhe/tests/unified_context_integration.rs
@@ -14,7 +14,7 @@ fn test_unified_context_api() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(params.degree(), 16);
     assert_eq!(params.plaintext(), 1153);
     assert_eq!(params.max_level(), 1);
-    assert_eq!(params.context_chain().collect_chain().len(), 2);
+    assert_eq!(params.context_chain().iter_chain().count(), 2);
 
     // Test level-based access
     let ctx_level_0 = params.context_at_level(0)?;


### PR DESCRIPTION
## Summary
- annotate public enums with `#[non_exhaustive]` for future-proofing
- avoid Vec allocations by returning iterators for default parameters and context chains
- adjust tests and benchmarks to new iterator APIs

## Testing
- `cargo +nightly fmt --all`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ab8465018c8323a282477ce91603a2