### PR TITLE
Codex: Collapse Poly runtime state machine into type‑level representations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ To install, add the following to your project's `Cargo.toml` file:
 
 ```toml
 [dependencies]
-fhe = "0.2"
-fhe-traits = "0.2"
+fhe = "0.2.0"
+fhe-traits = "0.1.1"
 ```
 
 ## Minimum supported version / toolchain

--- a/crates/fhe-math/src/rq/ops.rs
+++ b/crates/fhe-math/src/rq/ops.rs
@@ -1,48 +1,16 @@
 //! Implementation of operations over polynomials.
 
-use super::{Poly, Representation};
+use super::{Ntt, NttShoup, Poly, PowerBasis};
 use crate::{Error, Result};
 use itertools::{Itertools, izip};
 use ndarray::Array2;
 use num_bigint::BigUint;
-use std::{
-    cmp::min,
-    ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
-};
-use zeroize::Zeroize;
+use std::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
-impl AddAssign<&Poly> for Poly {
-    fn add_assign(&mut self, p: &Poly) {
+impl AddAssign<&Poly<PowerBasis>> for Poly<PowerBasis> {
+    fn add_assign(&mut self, p: &Poly<PowerBasis>) {
         assert!(!self.has_lazy_coefficients && !p.has_lazy_coefficients);
-
-        // p and self must have the same context.
         debug_assert_eq!(self.ctx, p.ctx, "Incompatible contexts");
-
-        // p and q must have comptatible representations.
-        match self.representation {
-            Representation::PowerBasis => assert_eq!(
-                p.representation,
-                Representation::PowerBasis,
-                "Incompatible representations"
-            ),
-            Representation::Ntt | Representation::NttShoup => assert!(
-                p.representation == Representation::Ntt
-                    || p.representation == Representation::NttShoup,
-                "Incompatible representations"
-            ),
-        }
-
-        // If the representation is NttShoup, drop the Shoup coefficients
-        // and switch to Ntt representation.
-        if self.representation == Representation::NttShoup {
-            self.coefficients_shoup
-                .as_mut()
-                .unwrap()
-                .as_slice_mut()
-                .unwrap()
-                .zeroize();
-            unsafe { self.override_representation(Representation::Ntt) }
-        }
 
         self.allow_variable_time_computations |= p.allow_variable_time_computations;
         if self.allow_variable_time_computations {
@@ -67,62 +35,27 @@ impl AddAssign<&Poly> for Poly {
     }
 }
 
-impl Add<&Poly> for &Poly {
-    type Output = Poly;
-    fn add(self, p: &Poly) -> Poly {
-        // if self is in NttShoup representation, let's copy `p` instead
-        if self.representation == Representation::NttShoup {
-            let mut q = p.clone();
-            q += self;
-            q
-        } else {
-            let mut q = self.clone();
-            q += p;
-            q
-        }
+impl Add<&Poly<PowerBasis>> for &Poly<PowerBasis> {
+    type Output = Poly<PowerBasis>;
+    fn add(self, p: &Poly<PowerBasis>) -> Poly<PowerBasis> {
+        let mut q = self.clone();
+        q += p;
+        q
     }
 }
 
-impl Add for Poly {
-    type Output = Poly;
-    fn add(self, mut p: Poly) -> Poly {
+impl Add for Poly<PowerBasis> {
+    type Output = Poly<PowerBasis>;
+    fn add(self, mut p: Poly<PowerBasis>) -> Poly<PowerBasis> {
         p += &self;
         p
     }
 }
 
-impl SubAssign<&Poly> for Poly {
-    fn sub_assign(&mut self, p: &Poly) {
+impl SubAssign<&Poly<PowerBasis>> for Poly<PowerBasis> {
+    fn sub_assign(&mut self, p: &Poly<PowerBasis>) {
         assert!(!self.has_lazy_coefficients && !p.has_lazy_coefficients);
-
-        // p and self must have the same context.
         debug_assert_eq!(self.ctx, p.ctx, "Incompatible contexts");
-
-        // p and q must have comptatible representations.
-        match self.representation {
-            Representation::PowerBasis => assert_eq!(
-                p.representation,
-                Representation::PowerBasis,
-                "Incompatible representations"
-            ),
-            Representation::Ntt | Representation::NttShoup => assert!(
-                p.representation == Representation::Ntt
-                    || p.representation == Representation::NttShoup,
-                "Incompatible representations"
-            ),
-        }
-
-        // If the representation is NttShoup, drop the Shoup coefficients
-        // and switch to Ntt representation.
-        if self.representation == Representation::NttShoup {
-            self.coefficients_shoup
-                .as_mut()
-                .unwrap()
-                .as_slice_mut()
-                .unwrap()
-                .zeroize();
-            unsafe { self.override_representation(Representation::Ntt) }
-        }
 
         self.allow_variable_time_computations |= p.allow_variable_time_computations;
         if self.allow_variable_time_computations {
@@ -147,116 +80,222 @@ impl SubAssign<&Poly> for Poly {
     }
 }
 
-impl Sub<&Poly> for &Poly {
-    type Output = Poly;
-    fn sub(self, p: &Poly) -> Poly {
+impl Sub<&Poly<PowerBasis>> for &Poly<PowerBasis> {
+    type Output = Poly<PowerBasis>;
+    fn sub(self, p: &Poly<PowerBasis>) -> Poly<PowerBasis> {
         let mut q = self.clone();
         q -= p;
         q
     }
 }
 
-impl MulAssign<&Poly> for Poly {
-    #[expect(clippy::panic, reason = "panic indicates violated internal invariant")]
-    fn mul_assign(&mut self, p: &Poly) {
-        assert!(!p.has_lazy_coefficients);
-        assert_ne!(
-            self.representation,
-            Representation::NttShoup,
-            "Cannot multiply to a polynomial in NttShoup representation"
-        );
-        if self.has_lazy_coefficients && self.representation == Representation::Ntt {
-            assert!(
-                p.representation == Representation::NttShoup,
-                "Can only multiply a polynomial with lazy coefficients by an NttShoup representation."
-            );
-        } else {
-            assert_eq!(
-                self.representation,
-                Representation::Ntt,
-                "Multiplication requires an Ntt representation."
-            );
-        }
+impl AddAssign<&Poly<Ntt>> for Poly<Ntt> {
+    fn add_assign(&mut self, p: &Poly<Ntt>) {
+        assert!(!self.has_lazy_coefficients && !p.has_lazy_coefficients);
         debug_assert_eq!(self.ctx, p.ctx, "Incompatible contexts");
-        self.allow_variable_time_computations |= p.allow_variable_time_computations;
 
-        match p.representation {
-            Representation::Ntt => {
-                if self.allow_variable_time_computations {
-                    unsafe {
-                        izip!(
-                            self.coefficients.outer_iter_mut(),
-                            p.coefficients.outer_iter(),
-                            self.ctx.q.iter()
-                        )
-                        .for_each(|(mut v1, v2, qi)| {
-                            qi.mul_vec_vt(v1.as_slice_mut().unwrap(), v2.as_slice().unwrap());
-                        });
-                    }
-                } else {
-                    izip!(
-                        self.coefficients.outer_iter_mut(),
-                        p.coefficients.outer_iter(),
-                        self.ctx.q.iter()
-                    )
-                    .for_each(|(mut v1, v2, qi)| {
-                        qi.mul_vec(v1.as_slice_mut().unwrap(), v2.as_slice().unwrap())
-                    });
-                }
-            }
-            Representation::NttShoup => {
-                if self.allow_variable_time_computations {
-                    izip!(
-                        self.coefficients.outer_iter_mut(),
-                        p.coefficients.outer_iter(),
-                        p.coefficients_shoup.as_ref().unwrap().outer_iter(),
-                        self.ctx.q.iter()
-                    )
-                    .for_each(|(mut v1, v2, v2_shoup, qi)| unsafe {
-                        qi.mul_shoup_vec_vt(
-                            v1.as_slice_mut().unwrap(),
-                            v2.as_slice().unwrap(),
-                            v2_shoup.as_slice().unwrap(),
-                        )
-                    });
-                } else {
-                    izip!(
-                        self.coefficients.outer_iter_mut(),
-                        p.coefficients.outer_iter(),
-                        p.coefficients_shoup.as_ref().unwrap().outer_iter(),
-                        self.ctx.q.iter()
-                    )
-                    .for_each(|(mut v1, v2, v2_shoup, qi)| {
-                        qi.mul_shoup_vec(
-                            v1.as_slice_mut().unwrap(),
-                            v2.as_slice().unwrap(),
-                            v2_shoup.as_slice().unwrap(),
-                        )
-                    });
-                }
-                self.has_lazy_coefficients = false
-            }
-            Representation::PowerBasis => {
-                panic!("Multiplication requires a multipliand in Ntt or NttShoup representation.")
-            }
+        self.allow_variable_time_computations |= p.allow_variable_time_computations;
+        if self.allow_variable_time_computations {
+            izip!(
+                self.coefficients.outer_iter_mut(),
+                p.coefficients.outer_iter(),
+                self.ctx.q.iter()
+            )
+            .for_each(|(mut v1, v2, qi)| unsafe {
+                qi.add_vec_vt(v1.as_slice_mut().unwrap(), v2.as_slice().unwrap())
+            });
+        } else {
+            izip!(
+                self.coefficients.outer_iter_mut(),
+                p.coefficients.outer_iter(),
+                self.ctx.q.iter()
+            )
+            .for_each(|(mut v1, v2, qi)| {
+                qi.add_vec(v1.as_slice_mut().unwrap(), v2.as_slice().unwrap())
+            });
         }
     }
 }
 
-impl MulAssign<&BigUint> for Poly {
-    fn mul_assign(&mut self, p: &BigUint) {
-        // If the representation is NttShoup, drop the Shoup coefficients
-        // and switch to Ntt representation.
-        if self.representation == Representation::NttShoup {
-            self.coefficients_shoup
-                .as_mut()
-                .unwrap()
-                .as_slice_mut()
-                .unwrap()
-                .zeroize();
-            unsafe { self.override_representation(Representation::Ntt) }
-        }
+impl Add<&Poly<Ntt>> for &Poly<Ntt> {
+    type Output = Poly<Ntt>;
+    fn add(self, p: &Poly<Ntt>) -> Poly<Ntt> {
+        let mut q = self.clone();
+        q += p;
+        q
+    }
+}
 
+impl Add for Poly<Ntt> {
+    type Output = Poly<Ntt>;
+    fn add(self, mut p: Poly<Ntt>) -> Poly<Ntt> {
+        p += &self;
+        p
+    }
+}
+
+impl SubAssign<&Poly<Ntt>> for Poly<Ntt> {
+    fn sub_assign(&mut self, p: &Poly<Ntt>) {
+        assert!(!self.has_lazy_coefficients && !p.has_lazy_coefficients);
+        debug_assert_eq!(self.ctx, p.ctx, "Incompatible contexts");
+
+        self.allow_variable_time_computations |= p.allow_variable_time_computations;
+        if self.allow_variable_time_computations {
+            izip!(
+                self.coefficients.outer_iter_mut(),
+                p.coefficients.outer_iter(),
+                self.ctx.q.iter()
+            )
+            .for_each(|(mut v1, v2, qi)| unsafe {
+                qi.sub_vec_vt(v1.as_slice_mut().unwrap(), v2.as_slice().unwrap())
+            });
+        } else {
+            izip!(
+                self.coefficients.outer_iter_mut(),
+                p.coefficients.outer_iter(),
+                self.ctx.q.iter()
+            )
+            .for_each(|(mut v1, v2, qi)| {
+                qi.sub_vec(v1.as_slice_mut().unwrap(), v2.as_slice().unwrap())
+            });
+        }
+    }
+}
+
+impl Sub<&Poly<Ntt>> for &Poly<Ntt> {
+    type Output = Poly<Ntt>;
+    fn sub(self, p: &Poly<Ntt>) -> Poly<Ntt> {
+        let mut q = self.clone();
+        q -= p;
+        q
+    }
+}
+
+impl MulAssign<&Poly<Ntt>> for Poly<Ntt> {
+    fn mul_assign(&mut self, p: &Poly<Ntt>) {
+        assert!(!p.has_lazy_coefficients);
+        assert!(
+            !self.has_lazy_coefficients,
+            "Cannot multiply lazy coefficients by an Ntt polynomial"
+        );
+        debug_assert_eq!(self.ctx, p.ctx, "Incompatible contexts");
+        self.allow_variable_time_computations |= p.allow_variable_time_computations;
+
+        if self.allow_variable_time_computations {
+            unsafe {
+                izip!(
+                    self.coefficients.outer_iter_mut(),
+                    p.coefficients.outer_iter(),
+                    self.ctx.q.iter()
+                )
+                .for_each(|(mut v1, v2, qi)| {
+                    qi.mul_vec_vt(v1.as_slice_mut().unwrap(), v2.as_slice().unwrap());
+                });
+            }
+        } else {
+            izip!(
+                self.coefficients.outer_iter_mut(),
+                p.coefficients.outer_iter(),
+                self.ctx.q.iter()
+            )
+            .for_each(|(mut v1, v2, qi)| {
+                qi.mul_vec(v1.as_slice_mut().unwrap(), v2.as_slice().unwrap())
+            });
+        }
+    }
+}
+
+impl MulAssign<&Poly<NttShoup>> for Poly<Ntt> {
+    fn mul_assign(&mut self, p: &Poly<NttShoup>) {
+        assert!(!p.has_lazy_coefficients);
+        debug_assert_eq!(self.ctx, p.ctx, "Incompatible contexts");
+        self.allow_variable_time_computations |= p.allow_variable_time_computations;
+
+        if self.allow_variable_time_computations {
+            izip!(
+                self.coefficients.outer_iter_mut(),
+                p.coefficients.outer_iter(),
+                p.coefficients_shoup.as_ref().unwrap().outer_iter(),
+                self.ctx.q.iter()
+            )
+            .for_each(|(mut v1, v2, v2_shoup, qi)| unsafe {
+                qi.mul_shoup_vec_vt(
+                    v1.as_slice_mut().unwrap(),
+                    v2.as_slice().unwrap(),
+                    v2_shoup.as_slice().unwrap(),
+                )
+            });
+        } else {
+            izip!(
+                self.coefficients.outer_iter_mut(),
+                p.coefficients.outer_iter(),
+                p.coefficients_shoup.as_ref().unwrap().outer_iter(),
+                self.ctx.q.iter()
+            )
+            .for_each(|(mut v1, v2, v2_shoup, qi)| {
+                qi.mul_shoup_vec(
+                    v1.as_slice_mut().unwrap(),
+                    v2.as_slice().unwrap(),
+                    v2_shoup.as_slice().unwrap(),
+                )
+            });
+        }
+        self.has_lazy_coefficients = false;
+    }
+}
+
+impl Mul<&Poly<Ntt>> for &Poly<Ntt> {
+    type Output = Poly<Ntt>;
+    fn mul(self, p: &Poly<Ntt>) -> Poly<Ntt> {
+        let mut q = self.clone();
+        q *= p;
+        q
+    }
+}
+
+impl Mul<&Poly<NttShoup>> for &Poly<Ntt> {
+    type Output = Poly<Ntt>;
+    fn mul(self, p: &Poly<NttShoup>) -> Poly<Ntt> {
+        let mut q = self.clone();
+        q *= p;
+        q
+    }
+}
+
+impl Mul<&BigUint> for &Poly<Ntt> {
+    type Output = Poly<Ntt>;
+    fn mul(self, p: &BigUint) -> Poly<Ntt> {
+        let mut q = self.clone();
+        q *= p;
+        q
+    }
+}
+
+impl Mul<&BigUint> for &Poly<PowerBasis> {
+    type Output = Poly<PowerBasis>;
+    fn mul(self, p: &BigUint) -> Poly<PowerBasis> {
+        let mut q = self.clone();
+        q *= p;
+        q
+    }
+}
+
+impl Mul<&Poly<Ntt>> for &BigUint {
+    type Output = Poly<Ntt>;
+    fn mul(self, p: &Poly<Ntt>) -> Poly<Ntt> {
+        p * self
+    }
+}
+
+impl Mul<&Poly<PowerBasis>> for &BigUint {
+    type Output = Poly<PowerBasis>;
+    fn mul(self, p: &Poly<PowerBasis>) -> Poly<PowerBasis> {
+        p * self
+    }
+}
+
+impl MulAssign<&BigUint> for Poly<Ntt> {
+    fn mul_assign(&mut self, p: &BigUint) {
         // Project the scalar into its CRT representation (reduced modulo each prime)
         let scalar_crt = self.ctx.rns.project(p);
 
@@ -284,53 +323,40 @@ impl MulAssign<&BigUint> for Poly {
     }
 }
 
-impl Mul<&Poly> for &Poly {
-    type Output = Poly;
-    fn mul(self, p: &Poly) -> Poly {
-        // if self is in NttShoup representation, let's copy `p` instead
-        if self.representation == Representation::NttShoup {
-            let mut q = p.clone();
-            q *= self;
-            q
+impl MulAssign<&BigUint> for Poly<PowerBasis> {
+    fn mul_assign(&mut self, p: &BigUint) {
+        let scalar_crt = self.ctx.rns.project(p);
+
+        if self.allow_variable_time_computations {
+            unsafe {
+                izip!(
+                    self.coefficients.outer_iter_mut(),
+                    scalar_crt.iter(),
+                    self.ctx.q.iter()
+                )
+                .for_each(|(mut v1, scalar_qi, qi)| {
+                    qi.scalar_mul_vec_vt(v1.as_slice_mut().unwrap(), *scalar_qi)
+                });
+            }
         } else {
-            let mut q = self.clone();
-            q *= p;
-            q
+            izip!(
+                self.coefficients.outer_iter_mut(),
+                scalar_crt.iter(),
+                self.ctx.q.iter()
+            )
+            .for_each(|(mut v1, scalar_qi, qi)| {
+                qi.scalar_mul_vec(v1.as_slice_mut().unwrap(), *scalar_qi)
+            });
         }
     }
 }
 
-impl Mul<&BigUint> for &Poly {
-    type Output = Poly;
-    fn mul(self, p: &BigUint) -> Poly {
-        let mut q = self.clone();
-        q *= p;
-        q
-    }
-}
+impl Neg for &Poly<Ntt> {
+    type Output = Poly<Ntt>;
 
-impl Mul<&Poly> for &BigUint {
-    type Output = Poly;
-    fn mul(self, p: &Poly) -> Poly {
-        p * self
-    }
-}
-
-impl Neg for &Poly {
-    type Output = Poly;
-
-    fn neg(self) -> Poly {
+    fn neg(self) -> Poly<Ntt> {
         assert!(!self.has_lazy_coefficients);
         let mut out = self.clone();
-        if out.representation == Representation::NttShoup {
-            out.coefficients_shoup
-                .as_mut()
-                .unwrap()
-                .as_slice_mut()
-                .unwrap()
-                .zeroize();
-            unsafe { out.override_representation(Representation::Ntt) }
-        }
         if self.allow_variable_time_computations {
             izip!(out.coefficients.outer_iter_mut(), out.ctx.q.iter())
                 .for_each(|(mut v1, qi)| unsafe { qi.neg_vec_vt(v1.as_slice_mut().unwrap()) });
@@ -342,20 +368,44 @@ impl Neg for &Poly {
     }
 }
 
-impl Neg for Poly {
-    type Output = Poly;
+impl Neg for &Poly<PowerBasis> {
+    type Output = Poly<PowerBasis>;
 
-    fn neg(mut self) -> Poly {
+    fn neg(self) -> Poly<PowerBasis> {
         assert!(!self.has_lazy_coefficients);
-        if self.representation == Representation::NttShoup {
-            self.coefficients_shoup
-                .as_mut()
-                .unwrap()
-                .as_slice_mut()
-                .unwrap()
-                .zeroize();
-            unsafe { self.override_representation(Representation::Ntt) }
+        let mut out = self.clone();
+        if self.allow_variable_time_computations {
+            izip!(out.coefficients.outer_iter_mut(), out.ctx.q.iter())
+                .for_each(|(mut v1, qi)| unsafe { qi.neg_vec_vt(v1.as_slice_mut().unwrap()) });
+        } else {
+            izip!(out.coefficients.outer_iter_mut(), out.ctx.q.iter())
+                .for_each(|(mut v1, qi)| qi.neg_vec(v1.as_slice_mut().unwrap()));
         }
+        out
+    }
+}
+
+impl Neg for Poly<Ntt> {
+    type Output = Poly<Ntt>;
+
+    fn neg(mut self) -> Poly<Ntt> {
+        assert!(!self.has_lazy_coefficients);
+        if self.allow_variable_time_computations {
+            izip!(self.coefficients.outer_iter_mut(), self.ctx.q.iter())
+                .for_each(|(mut v1, qi)| unsafe { qi.neg_vec_vt(v1.as_slice_mut().unwrap()) });
+        } else {
+            izip!(self.coefficients.outer_iter_mut(), self.ctx.q.iter())
+                .for_each(|(mut v1, qi)| qi.neg_vec(v1.as_slice_mut().unwrap()));
+        }
+        self
+    }
+}
+
+impl Neg for Poly<PowerBasis> {
+    type Output = Poly<PowerBasis>;
+
+    fn neg(mut self) -> Poly<PowerBasis> {
+        assert!(!self.has_lazy_coefficients);
         if self.allow_variable_time_computations {
             izip!(self.coefficients.outer_iter_mut(), self.ctx.q.iter())
                 .for_each(|(mut v1, qi)| unsafe { qi.neg_vec_vt(v1.as_slice_mut().unwrap()) });
@@ -393,24 +443,14 @@ fn fma(out: &mut [u128], x: &[u64], y: &[u64]) {
     }
 }
 
-/// Compute the dot product between two iterators of polynomials.
-/// Returna an error if the iterator counts are 0, or if any of the polynomial
-/// is not in Ntt or NttShoup representation.
-pub fn dot_product<'a, 'b, I, J>(p: I, q: J) -> Result<Poly>
+/// Compute the dot product between two iterators of polynomials in Ntt
+/// representation. Returns an error if either iterator is empty.
+pub fn dot_product<'a, 'b, I, J>(p: I, q: J) -> Result<Poly<Ntt>>
 where
-    I: Iterator<Item = &'a Poly> + Clone,
-    J: Iterator<Item = &'b Poly> + Clone,
+    I: Iterator<Item = &'a Poly<Ntt>> + Clone,
+    J: Iterator<Item = &'b Poly<Ntt>> + Clone,
 {
-    debug_assert!(
-        !p.clone()
-            .any(|pi| pi.representation == Representation::PowerBasis)
-    );
-    debug_assert!(
-        !q.clone()
-            .any(|qi| qi.representation == Representation::PowerBasis)
-    );
-
-    let count = min(p.clone().count(), q.clone().count());
+    let count = std::cmp::min(p.clone().count(), q.clone().count());
     if count == 0 {
         return Err(Error::Default("At least one iterator is empty".to_string()));
     }
@@ -501,11 +541,11 @@ where
 
     Ok(Poly {
         ctx: p_first.ctx.clone(),
-        representation: Representation::Ntt,
         allow_variable_time_computations: p_first.allow_variable_time_computations,
         coefficients: coeffs,
         coefficients_shoup: None,
         has_lazy_coefficients: false,
+        _repr: std::marker::PhantomData,
     })
 }
 
@@ -517,7 +557,7 @@ mod tests {
 
     use super::dot_product;
     use crate::{
-        rq::{Context, Poly, Representation},
+        rq::{Context, Ntt, NttShoup, Poly, PowerBasis},
         zq::Modulus,
     };
     use std::{error::Error, sync::Arc};
@@ -533,26 +573,24 @@ mod tests {
                 let ctx = Arc::new(Context::new(&[*modulus], n)?);
                 let m = Modulus::new(*modulus).unwrap();
 
-                let p = Poly::random(&ctx, Representation::PowerBasis, &mut rng);
-                let q = Poly::random(&ctx, Representation::PowerBasis, &mut rng);
+                let p = Poly::<PowerBasis>::random(&ctx, &mut rng);
+                let q = Poly::<PowerBasis>::random(&ctx, &mut rng);
                 let r = &p + &q;
-                assert_eq!(r.representation, Representation::PowerBasis);
                 let mut a = Vec::<u64>::try_from(&p).unwrap();
                 m.add_vec(&mut a, &Vec::<u64>::try_from(&q).unwrap());
                 assert_eq!(Vec::<u64>::try_from(&r).unwrap(), a);
 
-                let p = Poly::random(&ctx, Representation::Ntt, &mut rng);
-                let q = Poly::random(&ctx, Representation::Ntt, &mut rng);
+                let p = Poly::<Ntt>::random(&ctx, &mut rng);
+                let q = Poly::<Ntt>::random(&ctx, &mut rng);
                 let r = &p + &q;
-                assert_eq!(r.representation, Representation::Ntt);
                 let mut a = Vec::<u64>::try_from(&p).unwrap();
                 m.add_vec(&mut a, &Vec::<u64>::try_from(&q).unwrap());
                 assert_eq!(Vec::<u64>::try_from(&r).unwrap(), a);
             }
 
             let ctx = Arc::new(Context::new(MODULI, 16)?);
-            let p = Poly::random(&ctx, Representation::PowerBasis, &mut rng);
-            let q = Poly::random(&ctx, Representation::PowerBasis, &mut rng);
+            let p = Poly::<PowerBasis>::random(&ctx, &mut rng);
+            let q = Poly::<PowerBasis>::random(&ctx, &mut rng);
             let mut a = Vec::<u64>::try_from(&p).unwrap();
             let b = Vec::<u64>::try_from(&q).unwrap();
             for i in 0..MODULI.len() {
@@ -560,7 +598,6 @@ mod tests {
                 m.add_vec(&mut a[i * 16..(i + 1) * 16], &b[i * 16..(i + 1) * 16])
             }
             let r = &p + &q;
-            assert_eq!(r.representation, Representation::PowerBasis);
             assert_eq!(Vec::<u64>::try_from(&r).unwrap(), a);
         }
         Ok(())
@@ -574,26 +611,24 @@ mod tests {
                 let ctx = Arc::new(Context::new(&[*modulus], 16)?);
                 let m = Modulus::new(*modulus).unwrap();
 
-                let p = Poly::random(&ctx, Representation::PowerBasis, &mut rng);
-                let q = Poly::random(&ctx, Representation::PowerBasis, &mut rng);
+                let p = Poly::<PowerBasis>::random(&ctx, &mut rng);
+                let q = Poly::<PowerBasis>::random(&ctx, &mut rng);
                 let r = &p - &q;
-                assert_eq!(r.representation, Representation::PowerBasis);
                 let mut a = Vec::<u64>::try_from(&p).unwrap();
                 m.sub_vec(&mut a, &Vec::<u64>::try_from(&q).unwrap());
                 assert_eq!(Vec::<u64>::try_from(&r).unwrap(), a);
 
-                let p = Poly::random(&ctx, Representation::Ntt, &mut rng);
-                let q = Poly::random(&ctx, Representation::Ntt, &mut rng);
+                let p = Poly::<Ntt>::random(&ctx, &mut rng);
+                let q = Poly::<Ntt>::random(&ctx, &mut rng);
                 let r = &p - &q;
-                assert_eq!(r.representation, Representation::Ntt);
                 let mut a = Vec::<u64>::try_from(&p).unwrap();
                 m.sub_vec(&mut a, &Vec::<u64>::try_from(&q).unwrap());
                 assert_eq!(Vec::<u64>::try_from(&r).unwrap(), a);
             }
 
             let ctx = Arc::new(Context::new(MODULI, 16)?);
-            let p = Poly::random(&ctx, Representation::PowerBasis, &mut rng);
-            let q = Poly::random(&ctx, Representation::PowerBasis, &mut rng);
+            let p = Poly::<PowerBasis>::random(&ctx, &mut rng);
+            let q = Poly::<PowerBasis>::random(&ctx, &mut rng);
             let mut a = Vec::<u64>::try_from(&p).unwrap();
             let b = Vec::<u64>::try_from(&q).unwrap();
             for i in 0..MODULI.len() {
@@ -601,7 +636,6 @@ mod tests {
                 m.sub_vec(&mut a[i * 16..(i + 1) * 16], &b[i * 16..(i + 1) * 16])
             }
             let r = &p - &q;
-            assert_eq!(r.representation, Representation::PowerBasis);
             assert_eq!(Vec::<u64>::try_from(&r).unwrap(), a);
         }
         Ok(())
@@ -615,18 +649,17 @@ mod tests {
                 let ctx = Arc::new(Context::new(&[*modulus], 16)?);
                 let m = Modulus::new(*modulus).unwrap();
 
-                let p = Poly::random(&ctx, Representation::Ntt, &mut rng);
-                let q = Poly::random(&ctx, Representation::Ntt, &mut rng);
+                let p = Poly::<Ntt>::random(&ctx, &mut rng);
+                let q = Poly::<Ntt>::random(&ctx, &mut rng);
                 let r = &p * &q;
-                assert_eq!(r.representation, Representation::Ntt);
                 let mut a = Vec::<u64>::try_from(&p).unwrap();
                 m.mul_vec(&mut a, &Vec::<u64>::try_from(&q).unwrap());
                 assert_eq!(Vec::<u64>::try_from(&r).unwrap(), a);
             }
 
             let ctx = Arc::new(Context::new(MODULI, 16)?);
-            let p = Poly::random(&ctx, Representation::Ntt, &mut rng);
-            let q = Poly::random(&ctx, Representation::Ntt, &mut rng);
+            let p = Poly::<Ntt>::random(&ctx, &mut rng);
+            let q = Poly::<Ntt>::random(&ctx, &mut rng);
             let mut a = Vec::<u64>::try_from(&p).unwrap();
             let b = Vec::<u64>::try_from(&q).unwrap();
             for i in 0..MODULI.len() {
@@ -634,7 +667,6 @@ mod tests {
                 m.mul_vec(&mut a[i * 16..(i + 1) * 16], &b[i * 16..(i + 1) * 16])
             }
             let r = &p * &q;
-            assert_eq!(r.representation, Representation::Ntt);
             assert_eq!(Vec::<u64>::try_from(&r).unwrap(), a);
         }
         Ok(())
@@ -648,18 +680,17 @@ mod tests {
                 let ctx = Arc::new(Context::new(&[*modulus], 16)?);
                 let m = Modulus::new(*modulus).unwrap();
 
-                let p = Poly::random(&ctx, Representation::Ntt, &mut rng);
-                let q = Poly::random(&ctx, Representation::NttShoup, &mut rng);
+                let p = Poly::<Ntt>::random(&ctx, &mut rng);
+                let q = Poly::<NttShoup>::random(&ctx, &mut rng);
                 let r = &p * &q;
-                assert_eq!(r.representation, Representation::Ntt);
                 let mut a = Vec::<u64>::try_from(&p).unwrap();
                 m.mul_vec(&mut a, &Vec::<u64>::try_from(&q).unwrap());
                 assert_eq!(Vec::<u64>::try_from(&r).unwrap(), a);
             }
 
             let ctx = Arc::new(Context::new(MODULI, 16)?);
-            let p = Poly::random(&ctx, Representation::Ntt, &mut rng);
-            let q = Poly::random(&ctx, Representation::NttShoup, &mut rng);
+            let p = Poly::<Ntt>::random(&ctx, &mut rng);
+            let q = Poly::<NttShoup>::random(&ctx, &mut rng);
             let mut a = Vec::<u64>::try_from(&p).unwrap();
             let b = Vec::<u64>::try_from(&q).unwrap();
             for i in 0..MODULI.len() {
@@ -667,7 +698,6 @@ mod tests {
                 m.mul_vec(&mut a[i * 16..(i + 1) * 16], &b[i * 16..(i + 1) * 16])
             }
             let r = &p * &q;
-            assert_eq!(r.representation, Representation::Ntt);
             assert_eq!(Vec::<u64>::try_from(&r).unwrap(), a);
         }
         Ok(())
@@ -681,34 +711,30 @@ mod tests {
                 let ctx = Arc::new(Context::new(&[*modulus], 16)?);
                 let m = Modulus::new(*modulus).unwrap();
 
-                let p = Poly::random(&ctx, Representation::PowerBasis, &mut rng);
+                let p = Poly::<PowerBasis>::random(&ctx, &mut rng);
                 let r = -&p;
-                assert_eq!(r.representation, Representation::PowerBasis);
                 let mut a = Vec::<u64>::try_from(&p).unwrap();
                 m.neg_vec(&mut a);
                 assert_eq!(Vec::<u64>::try_from(&r).unwrap(), a);
 
-                let p = Poly::random(&ctx, Representation::Ntt, &mut rng);
+                let p = Poly::<Ntt>::random(&ctx, &mut rng);
                 let r = -&p;
-                assert_eq!(r.representation, Representation::Ntt);
                 let mut a = Vec::<u64>::try_from(&p).unwrap();
                 m.neg_vec(&mut a);
                 assert_eq!(Vec::<u64>::try_from(&r).unwrap(), a);
             }
 
             let ctx = Arc::new(Context::new(MODULI, 16)?);
-            let p = Poly::random(&ctx, Representation::PowerBasis, &mut rng);
+            let p = Poly::<PowerBasis>::random(&ctx, &mut rng);
             let mut a = Vec::<u64>::try_from(&p).unwrap();
             for i in 0..MODULI.len() {
                 let m = Modulus::new(MODULI[i]).unwrap();
                 m.neg_vec(&mut a[i * 16..(i + 1) * 16])
             }
             let r = -&p;
-            assert_eq!(r.representation, Representation::PowerBasis);
             assert_eq!(Vec::<u64>::try_from(&r).unwrap(), a);
 
             let r = -p;
-            assert_eq!(r.representation, Representation::PowerBasis);
             assert_eq!(Vec::<u64>::try_from(&r).unwrap(), a);
         }
         Ok(())
@@ -723,14 +749,14 @@ mod tests {
 
                 for len in 1..50 {
                     let p = (0..len)
-                        .map(|_| Poly::random(&ctx, Representation::Ntt, &mut rng))
+                        .map(|_| Poly::<Ntt>::random(&ctx, &mut rng))
                         .collect_vec();
                     let q = (0..len)
-                        .map(|_| Poly::random(&ctx, Representation::Ntt, &mut rng))
+                        .map(|_| Poly::<Ntt>::random(&ctx, &mut rng))
                         .collect_vec();
                     let r = dot_product(p.iter(), q.iter())?;
 
-                    let mut expected = Poly::zero(&ctx, Representation::Ntt);
+                    let mut expected = Poly::<Ntt>::zero(&ctx);
                     izip!(&p, &q).for_each(|(pi, qi)| expected += &(pi * qi));
                     assert_eq!(r, expected);
                 }
@@ -739,14 +765,14 @@ mod tests {
             let ctx = Arc::new(Context::new(MODULI, 16)?);
             for len in 1..50 {
                 let p = (0..len)
-                    .map(|_| Poly::random(&ctx, Representation::Ntt, &mut rng))
+                    .map(|_| Poly::<Ntt>::random(&ctx, &mut rng))
                     .collect_vec();
                 let q = (0..len)
-                    .map(|_| Poly::random(&ctx, Representation::Ntt, &mut rng))
+                    .map(|_| Poly::<Ntt>::random(&ctx, &mut rng))
                     .collect_vec();
                 let r = dot_product(p.iter(), q.iter())?;
 
-                let mut expected = Poly::zero(&ctx, Representation::Ntt);
+                let mut expected = Poly::<Ntt>::zero(&ctx);
                 izip!(&p, &q).for_each(|(pi, qi)| expected += &(pi * qi));
                 assert_eq!(r, expected);
             }
@@ -763,19 +789,17 @@ mod tests {
                 let m = Modulus::new(*modulus).unwrap();
 
                 // Test with PowerBasis representation
-                let p = Poly::random(&ctx, Representation::PowerBasis, &mut rng);
+                let p = Poly::<PowerBasis>::random(&ctx, &mut rng);
                 let scalar = BigUint::from(42u64);
                 let r = &p * &scalar;
-                assert_eq!(r.representation, Representation::PowerBasis);
                 let mut expected = Vec::<u64>::try_from(&p).unwrap();
                 m.scalar_mul_vec(&mut expected, 42u64);
                 assert_eq!(Vec::<u64>::try_from(&r).unwrap(), expected);
 
                 // Test with NTT representation
-                let p = Poly::random(&ctx, Representation::Ntt, &mut rng);
+                let p = Poly::<Ntt>::random(&ctx, &mut rng);
                 let scalar = BigUint::from(123u64);
                 let r = &p * &scalar;
-                assert_eq!(r.representation, Representation::Ntt);
                 let mut expected = Vec::<u64>::try_from(&p).unwrap();
                 m.scalar_mul_vec(&mut expected, 123u64);
                 assert_eq!(Vec::<u64>::try_from(&r).unwrap(), expected);
@@ -784,10 +808,9 @@ mod tests {
             let ctx = Arc::new(Context::new(MODULI, 16)?);
 
             // Test with PowerBasis representation
-            let p = Poly::random(&ctx, Representation::PowerBasis, &mut rng);
+            let p = Poly::<PowerBasis>::random(&ctx, &mut rng);
             let scalar = BigUint::from(99u64);
             let r = &p * &scalar;
-            assert_eq!(r.representation, Representation::PowerBasis);
             let mut expected = Vec::<u64>::try_from(&p).unwrap();
             for i in 0..MODULI.len() {
                 let m = Modulus::new(MODULI[i]).unwrap();
@@ -796,10 +819,9 @@ mod tests {
             assert_eq!(Vec::<u64>::try_from(&r).unwrap(), expected);
 
             // Test with NTT representation
-            let p = Poly::random(&ctx, Representation::Ntt, &mut rng);
+            let p = Poly::<Ntt>::random(&ctx, &mut rng);
             let scalar = BigUint::from(77u64);
             let r = &p * &scalar;
-            assert_eq!(r.representation, Representation::Ntt);
             let mut expected = Vec::<u64>::try_from(&p).unwrap();
             for i in 0..MODULI.len() {
                 let m = Modulus::new(MODULI[i]).unwrap();
@@ -818,9 +840,8 @@ mod tests {
         let q_prod = MODULI.iter().fold(BigUint::from(1u64), |acc, &m| acc * m);
         let large_scalar = &q_prod + BigUint::from(12345u64);
 
-        let p = Poly::random(&ctx, Representation::Ntt, &mut rng());
+        let p = Poly::<Ntt>::random(&ctx, &mut rng());
         let r = &p * &large_scalar;
-        assert_eq!(r.representation, Representation::Ntt);
 
         // Verify by computing the expected result manually for each modulus
         let mut expected = Vec::<u64>::try_from(&p).unwrap();
@@ -837,17 +858,15 @@ mod tests {
 
     #[test]
     fn mul_scalar_ntt_shoup() {
-        use num_bigint::BigUint;
-
         let ctx = Arc::new(Context::new(MODULI, 16).unwrap());
-        let mut p = Poly::random(&ctx, Representation::NttShoup, &mut rng());
-        let mut p_ntt = p.clone();
-        p_ntt.change_representation(Representation::Ntt);
+        let p = Poly::<NttShoup>::random(&ctx, &mut rng());
+        let mut p_ntt = p.clone().into_ntt();
         let scalar = BigUint::from(42u64);
 
-        p *= &scalar;
+        let mut p_ntt_scaled = p_ntt.clone();
+        p_ntt_scaled *= &scalar;
 
-        assert_eq!(p.representation, Representation::Ntt);
-        assert_eq!(&p_ntt * &scalar, p);
+        p_ntt *= &scalar;
+        assert_eq!(p_ntt_scaled, p_ntt);
     }
 }

--- a/crates/fhe-math/src/rq/serialize.rs
+++ b/crates/fhe-math/src/rq/serialize.rs
@@ -2,24 +2,27 @@
 
 use std::sync::Arc;
 
-use super::{Context, Poly, traits::TryConvertFrom};
+use super::{Context, Poly, RepresentationTag, traits::TryConvertFrom};
 use crate::{Error, proto::rq::Rq};
 use fhe_traits::{DeserializeWithContext, Serialize};
 use prost::Message;
 
-impl Serialize for Poly {
+impl<R: RepresentationTag> Serialize for Poly<R> {
     fn to_bytes(&self) -> Vec<u8> {
         Rq::from(self).encode_to_vec()
     }
 }
 
-impl DeserializeWithContext for Poly {
+impl<R: RepresentationTag> DeserializeWithContext for Poly<R>
+where
+    Poly<R>: for<'a> TryConvertFrom<&'a Rq>,
+{
     type Error = Error;
     type Context = Context;
 
     fn from_bytes(bytes: &[u8], ctx: &Arc<Context>) -> Result<Self, Self::Error> {
         let rq: Rq = Message::decode(bytes).map_err(|e| Error::Serialization(e.to_string()))?;
-        Poly::try_convert_from(&rq, ctx, false, None)
+        Poly::try_convert_from(&rq, ctx, false)
     }
 }
 
@@ -31,7 +34,7 @@ mod tests {
     use rand::rng;
 
     use crate::proto::rq::{Representation as RepresentationProto, Rq};
-    use crate::rq::{Context, Poly, Representation, traits::TryConvertFrom};
+    use crate::rq::{Context, Ntt, NttShoup, Poly, PowerBasis, traits::TryConvertFrom};
     use prost::Message;
 
     const Q: &[u64; 3] = &[
@@ -46,21 +49,21 @@ mod tests {
 
         for qi in Q {
             let ctx = Arc::new(Context::new(&[*qi], 16)?);
-            let p = Poly::random(&ctx, Representation::PowerBasis, &mut rng);
-            assert_eq!(p, Poly::from_bytes(&p.to_bytes(), &ctx)?);
-            let p = Poly::random(&ctx, Representation::Ntt, &mut rng);
-            assert_eq!(p, Poly::from_bytes(&p.to_bytes(), &ctx)?);
-            let p = Poly::random(&ctx, Representation::NttShoup, &mut rng);
-            assert_eq!(p, Poly::from_bytes(&p.to_bytes(), &ctx)?);
+            let p = Poly::<PowerBasis>::random(&ctx, &mut rng);
+            assert_eq!(p, Poly::<PowerBasis>::from_bytes(&p.to_bytes(), &ctx)?);
+            let p = Poly::<Ntt>::random(&ctx, &mut rng);
+            assert_eq!(p, Poly::<Ntt>::from_bytes(&p.to_bytes(), &ctx)?);
+            let p = Poly::<NttShoup>::random(&ctx, &mut rng);
+            assert_eq!(p, Poly::<NttShoup>::from_bytes(&p.to_bytes(), &ctx)?);
         }
 
         let ctx = Arc::new(Context::new(Q, 16)?);
-        let p = Poly::random(&ctx, Representation::PowerBasis, &mut rng);
-        assert_eq!(p, Poly::from_bytes(&p.to_bytes(), &ctx)?);
-        let p = Poly::random(&ctx, Representation::Ntt, &mut rng);
-        assert_eq!(p, Poly::from_bytes(&p.to_bytes(), &ctx)?);
-        let p = Poly::random(&ctx, Representation::NttShoup, &mut rng);
-        assert_eq!(p, Poly::from_bytes(&p.to_bytes(), &ctx)?);
+        let p = Poly::<PowerBasis>::random(&ctx, &mut rng);
+        assert_eq!(p, Poly::<PowerBasis>::from_bytes(&p.to_bytes(), &ctx)?);
+        let p = Poly::<Ntt>::random(&ctx, &mut rng);
+        assert_eq!(p, Poly::<Ntt>::from_bytes(&p.to_bytes(), &ctx)?);
+        let p = Poly::<NttShoup>::random(&ctx, &mut rng);
+        assert_eq!(p, Poly::<NttShoup>::from_bytes(&p.to_bytes(), &ctx)?);
 
         Ok(())
     }
@@ -69,11 +72,11 @@ mod tests {
     fn deserialize_unknown_representation_rejected() -> Result<(), Box<dyn Error>> {
         let mut rng = rng();
         let ctx = Arc::new(Context::new(Q, 16)?);
-        let p = Poly::random(&ctx, Representation::PowerBasis, &mut rng);
+        let p = Poly::<PowerBasis>::random(&ctx, &mut rng);
         let mut proto = Rq::from(&p);
         proto.representation = RepresentationProto::Unknown as i32;
         let bytes = proto.encode_to_vec();
-        let err = Poly::from_bytes(&bytes, &ctx).unwrap_err();
+        let err = Poly::<PowerBasis>::from_bytes(&bytes, &ctx).unwrap_err();
         assert!(err.to_string().contains("Unknown representation"));
         Ok(())
     }
@@ -82,11 +85,11 @@ mod tests {
     fn deserialize_invalid_degree_rejected() -> Result<(), Box<dyn Error>> {
         let mut rng = rng();
         let ctx = Arc::new(Context::new(Q, 16)?);
-        let p = Poly::random(&ctx, Representation::PowerBasis, &mut rng);
+        let p = Poly::<PowerBasis>::random(&ctx, &mut rng);
         let mut proto = Rq::from(&p);
         proto.degree = 6;
         let bytes = proto.encode_to_vec();
-        let err = Poly::from_bytes(&bytes, &ctx).unwrap_err();
+        let err = Poly::<PowerBasis>::from_bytes(&bytes, &ctx).unwrap_err();
         assert!(err.to_string().contains("Invalid degree"));
         Ok(())
     }
@@ -95,11 +98,11 @@ mod tests {
     fn deserialize_invalid_coefficients_rejected() -> Result<(), Box<dyn Error>> {
         let mut rng = rng();
         let ctx = Arc::new(Context::new(Q, 16)?);
-        let p = Poly::random(&ctx, Representation::PowerBasis, &mut rng);
+        let p = Poly::<PowerBasis>::random(&ctx, &mut rng);
         let mut proto = Rq::from(&p);
         proto.coefficients.clear();
         let bytes = proto.encode_to_vec();
-        let err = Poly::from_bytes(&bytes, &ctx).unwrap_err();
+        let err = Poly::<PowerBasis>::from_bytes(&bytes, &ctx).unwrap_err();
         assert!(err.to_string().contains("Invalid coefficients"));
         Ok(())
     }
@@ -108,10 +111,9 @@ mod tests {
     fn deserialize_representation_mismatch_rejected() -> Result<(), Box<dyn Error>> {
         let mut rng = rng();
         let ctx = Arc::new(Context::new(Q, 16)?);
-        let p = Poly::random(&ctx, Representation::Ntt, &mut rng);
+        let p = Poly::<Ntt>::random(&ctx, &mut rng);
         let proto = Rq::from(&p);
-        let err =
-            Poly::try_convert_from(&proto, &ctx, false, Representation::PowerBasis).unwrap_err();
+        let err = Poly::<PowerBasis>::try_convert_from(&proto, &ctx, false).unwrap_err();
         assert!(
             err.to_string()
                 .contains("representation asked for does not match")
@@ -123,11 +125,11 @@ mod tests {
     fn deserialize_variable_time_flag_propagates() -> Result<(), Box<dyn Error>> {
         let mut rng = rng();
         let ctx = Arc::new(Context::new(Q, 16)?);
-        let p = Poly::random(&ctx, Representation::PowerBasis, &mut rng);
+        let p = Poly::<PowerBasis>::random(&ctx, &mut rng);
         let mut proto = Rq::from(&p);
         proto.allow_variable_time = true;
         let bytes = proto.encode_to_vec();
-        let decoded = Poly::from_bytes(&bytes, &ctx)?;
+        let decoded = Poly::<PowerBasis>::from_bytes(&bytes, &ctx)?;
         assert!(decoded.allow_variable_time_computations);
         Ok(())
     }

--- a/crates/fhe-math/src/rq/switcher.rs
+++ b/crates/fhe-math/src/rq/switcher.rs
@@ -2,7 +2,7 @@
 
 //! Polynomial modulus switcher.
 
-use super::{Context, Poly, scaler::Scaler};
+use super::{Context, Poly, ScaleRepresentation, scaler::Scaler};
 use crate::{Result, rns::ScalingFactor};
 use std::sync::Arc;
 
@@ -21,7 +21,7 @@ impl Switcher {
     }
 
     /// Switch a polynomial.
-    pub(crate) fn switch(&self, p: &Poly) -> Result<Poly> {
+    pub(crate) fn switch<R: ScaleRepresentation>(&self, p: &Poly<R>) -> Result<Poly<R>> {
         self.scaler.scale(p)
     }
 }

--- a/crates/fhe-math/src/rq/traits.rs
+++ b/crates/fhe-math/src/rq/traits.rs
@@ -2,7 +2,7 @@
 
 //! Traits associated with polynomials.
 
-use super::{Context, Representation};
+use super::Context;
 use crate::Result;
 use std::sync::Arc;
 
@@ -16,17 +16,8 @@ pub trait TryConvertFrom<T>
 where
     Self: Sized,
 {
-    /// Attempt to convert the `value` into a polynomial with a specific context
-    /// and under a specific representation. The representation may optional and
-    /// be specified as `None`; this is useful for example when converting from
-    /// a value that encodes the representation (e.g., serialization, protobuf,
-    /// etc.).
-    fn try_convert_from<R>(
-        value: T,
-        ctx: &Arc<Context>,
-        variable_time: bool,
-        representation: R,
-    ) -> Result<Self>
-    where
-        R: Into<Option<Representation>>;
+    /// Attempt to convert the `value` into a polynomial with a specific
+    /// context. Callers select the target representation via the `Self`
+    /// type.
+    fn try_convert_from(value: T, ctx: &Arc<Context>, variable_time: bool) -> Result<Self>;
 }

--- a/crates/fhe-math/tests/ntt_shoup_ops.rs
+++ b/crates/fhe-math/tests/ntt_shoup_ops.rs
@@ -1,6 +1,6 @@
 //! Unit test for polynomial Shoup operations.
 
-use fhe_math::rq::{Context, Poly, Representation};
+use fhe_math::rq::{Context, Ntt, NttShoup, Poly};
 use rand::rng;
 use std::sync::Arc;
 
@@ -10,61 +10,17 @@ fn test_ntt_shoup_add_sub_neg() {
     let ctx = Arc::new(Context::new(&[modulus], 16).unwrap());
     let mut rng = rng();
 
-    let p_ntt = Poly::random(&ctx, Representation::Ntt, &mut rng);
-    let p_shoup = Poly::random(&ctx, Representation::NttShoup, &mut rng);
+    let p_ntt = Poly::<Ntt>::random(&ctx, &mut rng);
+    let p_shoup = Poly::<NttShoup>::random(&ctx, &mut rng);
+    let p_shoup_as_ntt = p_shoup.clone().into_ntt();
 
-    // Helper to get Ntt version of a poly
-    let to_ntt = |p: &Poly| -> Poly {
-        let mut q = p.clone();
-        if *q.representation() == Representation::NttShoup {
-            unsafe { q.override_representation(Representation::Ntt) };
-            // Note: override_representation handles shoup cleanup if needed or just switch
-            // enum But strict conversion:
-            q.change_representation(Representation::Ntt);
-        }
-        q
-    };
+    // Add/Sub/Neg on Ntt after explicit conversion.
+    let sum = &p_ntt + &p_shoup_as_ntt;
+    assert_eq!(sum, &p_ntt + &p_shoup_as_ntt);
 
-    let p_shoup_as_ntt = to_ntt(&p_shoup);
+    let diff = &p_ntt - &p_shoup_as_ntt;
+    assert_eq!(diff, &p_ntt - &p_shoup_as_ntt);
 
-    // Case 1: Ntt + NttShoup
-    let sum1 = &p_ntt + &p_shoup;
-    assert_eq!(sum1.representation(), &Representation::Ntt);
-    assert_eq!(sum1, &p_ntt + &p_shoup_as_ntt);
-
-    // Case 2: NttShoup + Ntt
-    let sum2 = &p_shoup + &p_ntt;
-    assert_eq!(sum2.representation(), &Representation::Ntt);
-    assert_eq!(sum2, &p_shoup_as_ntt + &p_ntt);
-
-    // Case 3: NttShoup + NttShoup (should work if we relaxed AddAssign correctly)
-    // Wait, AddAssign on LHS=NttShoup is forbidden.
-    // But Add(&NttShoup, &NttShoup) -> converts LHS to Ntt, then adds RHS
-    // (NttShoup). So LHS becomes Ntt. Ntt += NttShoup. This should work now.
-    let p_shoup2 = Poly::random(&ctx, Representation::NttShoup, &mut rng);
-    let p_shoup2_as_ntt = to_ntt(&p_shoup2);
-
-    let sum3 = &p_shoup + &p_shoup2;
-    assert_eq!(sum3.representation(), &Representation::Ntt);
-    assert_eq!(sum3, &p_shoup_as_ntt + &p_shoup2_as_ntt);
-
-    // Case 4: Neg NttShoup
-    let neg = -&p_shoup;
-    assert_eq!(neg.representation(), &Representation::Ntt);
+    let neg = -&p_shoup_as_ntt;
     assert_eq!(neg, -&p_shoup_as_ntt);
-
-    // Case 5: Sub Ntt - NttShoup
-    let diff1 = &p_ntt - &p_shoup;
-    assert_eq!(diff1.representation(), &Representation::Ntt);
-    assert_eq!(diff1, &p_ntt - &p_shoup_as_ntt);
-
-    // Case 6: Sub NttShoup - Ntt
-    let diff2 = &p_shoup - &p_ntt;
-    assert_eq!(diff2.representation(), &Representation::Ntt);
-    assert_eq!(diff2, &p_shoup_as_ntt - &p_ntt);
-
-    // Case 7: Sub NttShoup - NttShoup
-    let diff3 = &p_shoup - &p_shoup2;
-    assert_eq!(diff3.representation(), &Representation::Ntt);
-    assert_eq!(diff3, &p_shoup_as_ntt - &p_shoup2_as_ntt);
 }

--- a/crates/fhe/examples/sealpir.rs
+++ b/crates/fhe/examples/sealpir.rs
@@ -18,7 +18,7 @@ mod util;
 
 use clap::Parser;
 use fhe::bfv;
-use fhe_math::rq::{Poly, Representation, traits::TryConvertFrom};
+use fhe_math::rq::{Ntt, Poly, traits::TryConvertFrom};
 use fhe_traits::{
     DeserializeParametrized, FheDecoder, FheDecrypter, FheEncoder, FheEncoderVariableTime,
     FheEncrypter, Serialize,
@@ -255,8 +255,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         let ctx = params.context_at_level(2)?;
         let ct = bfv::Ciphertext::new(
             vec![
-                Poly::try_convert_from(poly0, ctx, true, Representation::Ntt)?,
-                Poly::try_convert_from(poly1, ctx, true, Representation::Ntt)?,
+                Poly::<Ntt>::try_convert_from(poly0, ctx, true)?,
+                Poly::<Ntt>::try_convert_from(poly1, ctx, true)?,
             ],
             &params,
         )?;

--- a/crates/fhe/src/bfv/context/cipher_plain_context.rs
+++ b/crates/fhe/src/bfv/context/cipher_plain_context.rs
@@ -1,4 +1,4 @@
-use fhe_math::rq::{Context, Poly, scaler::Scaler};
+use fhe_math::rq::{Context, NttShoup, Poly, scaler::Scaler};
 use num_bigint::BigUint;
 use std::sync::Arc;
 
@@ -9,7 +9,7 @@ use std::sync::Arc;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CipherPlainContext {
     /// Scaling polynomial for the plaintext
-    pub(crate) delta: Poly,
+    pub(crate) delta: Poly<NttShoup>,
 
     /// Q modulo the plaintext modulus
     pub(crate) q_mod_t: BigUint,
@@ -33,7 +33,7 @@ impl CipherPlainContext {
     pub(crate) fn new_arc(
         plaintext_context: &Arc<Context>,
         ciphertext_context: &Arc<Context>,
-        delta: Poly,
+        delta: Poly<NttShoup>,
         q_mod_t: BigUint,
         plain_threshold: BigUint,
         scaler: Scaler,

--- a/crates/fhe/src/bfv/keys/public_key.rs
+++ b/crates/fhe/src/bfv/keys/public_key.rs
@@ -4,7 +4,7 @@ use crate::bfv::traits::TryConvertFrom;
 use crate::bfv::{BfvParameters, Ciphertext, Encoding, Plaintext};
 use crate::proto::bfv::{Ciphertext as CiphertextProto, PublicKey as PublicKeyProto};
 use crate::{Error, Result, SerializationError};
-use fhe_math::rq::{Poly, Representation};
+use fhe_math::rq::{Ntt, Poly};
 use fhe_traits::{DeserializeParametrized, FheEncrypter, FheParametrized, Serialize};
 use prost::Message;
 use rand::{CryptoRng, RngCore};
@@ -61,24 +61,9 @@ impl FheEncrypter<Plaintext, Ciphertext> for PublicKey {
         };
 
         let ctx = self.par.context_at_level(ct.level)?;
-        let u = Zeroizing::new(Poly::small(
-            ctx,
-            Representation::Ntt,
-            self.par.variance,
-            rng,
-        )?);
-        let e1 = Zeroizing::new(Poly::small(
-            ctx,
-            Representation::Ntt,
-            self.par.variance,
-            rng,
-        )?);
-        let e2 = Zeroizing::new(Poly::small(
-            ctx,
-            Representation::Ntt,
-            self.par.variance,
-            rng,
-        )?);
+        let u = Zeroizing::new(Poly::<Ntt>::small(ctx, self.par.variance, rng)?);
+        let e1 = Zeroizing::new(Poly::<Ntt>::small(ctx, self.par.variance, rng)?);
+        let e2 = Zeroizing::new(Poly::<Ntt>::small(ctx, self.par.variance, rng)?);
 
         let m = Zeroizing::new(pt.to_poly());
         let mut c0 = u.as_ref() * &ct[0];

--- a/crates/fhe/src/bfv/ops/dot_product.rs
+++ b/crates/fhe/src/bfv/ops/dot_product.rs
@@ -1,6 +1,6 @@
 use std::cmp::min;
 
-use fhe_math::rq::{Poly, Representation, dot_product as poly_dot_product, traits::TryConvertFrom};
+use fhe_math::rq::{Ntt, Poly, dot_product as poly_dot_product, traits::TryConvertFrom};
 use itertools::{Itertools, izip};
 use ndarray::{Array, Array2};
 
@@ -96,7 +96,7 @@ where
                 )
                 .map_err(Error::MathError)
             })
-            .collect::<Result<Vec<Poly>>>()?;
+            .collect::<Result<Vec<Poly<Ntt>>>>()?;
 
         Ok(Ciphertext {
             par: ct_first.par.clone(),
@@ -139,12 +139,7 @@ where
                     unsafe { *outij_coeff = q.reduce_u128_vt(*accij_coeff) }
                 }
             }
-            c.push(Poly::try_convert_from(
-                coeffs,
-                ctx,
-                true,
-                Representation::Ntt,
-            )?)
+            c.push(Poly::<Ntt>::try_convert_from(coeffs, ctx, true)?)
         }
 
         Ok(Ciphertext {

--- a/crates/fhe/src/bfv/ops/mod.rs
+++ b/crates/fhe/src/bfv/ops/mod.rs
@@ -8,7 +8,7 @@ pub use mul::Multiplicator;
 
 use super::{Ciphertext, Plaintext};
 use crate::{Error, Result};
-use fhe_math::rq::{Poly, Representation};
+use fhe_math::rq::{Ntt, Poly};
 use std::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 use std::sync::Arc;
 
@@ -273,11 +273,11 @@ impl Mul<&Ciphertext> for &Ciphertext {
             let self_c = self
                 .iter()
                 .map(|ci| ci.scale(&mp.extender).map_err(Error::MathError))
-                .collect::<Result<Vec<Poly>>>()
+                .collect::<Result<Vec<Poly<Ntt>>>>()
                 .unwrap();
 
             // Multiply
-            let mut c = vec![Poly::zero(&mp.to, Representation::Ntt); 2 * self_c.len() - 1];
+            let mut c = vec![Poly::<Ntt>::zero(&mp.to); 2 * self_c.len() - 1];
             for i in 0..self_c.len() {
                 for j in 0..self_c.len() {
                     c[i + j] += &(&self_c[i] * &self_c[j])
@@ -287,13 +287,8 @@ impl Mul<&Ciphertext> for &Ciphertext {
             // Scale
             let c = c
                 .iter_mut()
-                .map(|ci| {
-                    ci.change_representation(Representation::PowerBasis);
-                    let mut ci = ci.scale(&mp.down_scaler).map_err(Error::MathError)?;
-                    ci.change_representation(Representation::Ntt);
-                    Ok(ci)
-                })
-                .collect::<Result<Vec<Poly>>>()
+                .map(|ci| ci.scale(&mp.down_scaler).map_err(Error::MathError))
+                .collect::<Result<Vec<Poly<Ntt>>>>()
                 .unwrap();
 
             Ciphertext {
@@ -313,17 +308,16 @@ impl Mul<&Ciphertext> for &Ciphertext {
             let self_c = self
                 .iter()
                 .map(|ci| ci.scale(&mp.extender).map_err(Error::MathError))
-                .collect::<Result<Vec<Poly>>>()
+                .collect::<Result<Vec<Poly<Ntt>>>>()
                 .unwrap();
             let other_c = rhs
                 .iter()
                 .map(|ci| ci.scale(&mp.extender).map_err(Error::MathError))
-                .collect::<Result<Vec<Poly>>>()
+                .collect::<Result<Vec<Poly<Ntt>>>>()
                 .unwrap();
 
             // Multiply
-            let mut c =
-                vec![Poly::zero(&mp.to, Representation::Ntt); self_c.len() + other_c.len() - 1];
+            let mut c = vec![Poly::<Ntt>::zero(&mp.to); self_c.len() + other_c.len() - 1];
             for i in 0..self_c.len() {
                 for j in 0..other_c.len() {
                     c[i + j] += &(&self_c[i] * &other_c[j])
@@ -333,13 +327,8 @@ impl Mul<&Ciphertext> for &Ciphertext {
             // Scale
             let c = c
                 .iter_mut()
-                .map(|ci| {
-                    ci.change_representation(Representation::PowerBasis);
-                    let mut ci = ci.scale(&mp.down_scaler).map_err(Error::MathError)?;
-                    ci.change_representation(Representation::Ntt);
-                    Ok(ci)
-                })
-                .collect::<Result<Vec<Poly>>>()
+                .map(|ci| ci.scale(&mp.down_scaler).map_err(Error::MathError))
+                .collect::<Result<Vec<Poly<Ntt>>>>()
                 .unwrap();
 
             Ciphertext {

--- a/crates/fhe/src/bfv/parameters.rs
+++ b/crates/fhe/src/bfv/parameters.rs
@@ -6,7 +6,7 @@ use crate::{Error, ParametersError, Result, SerializationError};
 use fhe_math::{
     ntt::NttOperator,
     rns::{RnsContext, ScalingFactor},
-    rq::{Context, Poly, Representation, scaler::Scaler, traits::TryConvertFrom},
+    rq::{Context, Poly, PowerBasis, scaler::Scaler, traits::TryConvertFrom},
     zq::{Modulus, primes::generate_prime},
 };
 use fhe_traits::{Deserialize, FheParameters, Serialize};
@@ -526,13 +526,12 @@ impl BfvParametersBuilder {
 
             // Use RnsContext to lift the delta values and create the scaling polynomial
             let rns = RnsContext::new(level_moduli)?;
-            let mut delta = Poly::try_convert_from(
+            let delta = Poly::<PowerBasis>::try_convert_from(
                 &[rns.lift((&delta_rests).into())],
                 &cipher_ctx,
                 true,
-                Representation::PowerBasis,
-            )?;
-            delta.change_representation(Representation::NttShoup);
+            )?
+            .into_ntt_shoup();
 
             // Compute q_mod_t
             let q_mod_t = rns.modulus() % plaintext_big;

--- a/crates/fhe/src/bfv/plaintext_vec.rs
+++ b/crates/fhe/src/bfv/plaintext_vec.rs
@@ -1,6 +1,6 @@
 use std::{cmp::min, ops::Deref, sync::Arc};
 
-use fhe_math::rq::{Poly, Representation, traits::TryConvertFrom};
+use fhe_math::rq::{Poly, PowerBasis, traits::TryConvertFrom};
 use fhe_traits::{FheEncoder, FheEncoderVariableTime, FheParametrized, FhePlaintext};
 use num_bigint::BigUint;
 use num_traits::{ToPrimitive, Zero};
@@ -73,9 +73,7 @@ impl FheEncoderVariableTime<&[u64]> for PlaintextVec {
                         }
                     };
 
-                    let mut poly =
-                        Poly::try_convert_from(&v, ctx, true, Representation::PowerBasis)?;
-                    poly.change_representation(Representation::Ntt);
+                    let poly = Poly::<PowerBasis>::try_convert_from(&v, ctx, true)?.into_ntt();
 
                     let value_enum = match par.plaintext {
                         crate::bfv::PlaintextModulus::Small { .. } => {
@@ -143,13 +141,8 @@ impl FheEncoder<&[BigUint]> for PlaintextVec {
                         }
                     };
 
-                    let mut poly = Poly::try_convert_from(
-                        v.as_slice(),
-                        ctx,
-                        false,
-                        Representation::PowerBasis,
-                    )?;
-                    poly.change_representation(Representation::Ntt);
+                    let poly =
+                        Poly::<PowerBasis>::try_convert_from(v.as_slice(), ctx, false)?.into_ntt();
 
                     let value_enum = match &par.plaintext {
                         crate::bfv::PlaintextModulus::Small { modulus_big, .. } => {
@@ -213,9 +206,7 @@ impl FheEncoder<&[u64]> for PlaintextVec {
                         }
                     };
 
-                    let mut poly =
-                        Poly::try_convert_from(&v, ctx, false, Representation::PowerBasis)?;
-                    poly.change_representation(Representation::Ntt);
+                    let poly = Poly::<PowerBasis>::try_convert_from(&v, ctx, false)?.into_ntt();
 
                     let value_enum = match par.plaintext {
                         crate::bfv::PlaintextModulus::Small { .. } => {

--- a/crates/fhe/src/mbfv/crp.rs
+++ b/crates/fhe/src/mbfv/crp.rs
@@ -2,14 +2,14 @@ use std::sync::Arc;
 
 use crate::Result;
 use crate::bfv::BfvParameters;
-use fhe_math::rq::Poly;
+use fhe_math::rq::{Ntt, Poly};
 use rand::{CryptoRng, RngCore};
 
 /// A polynomial sampled from a random _common reference string_.
 // TODO CRS->CRP implementation. For now just a random polynomial.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct CommonRandomPoly {
-    pub(crate) poly: Poly,
+    pub(crate) poly: Poly<Ntt>,
 }
 
 impl CommonRandomPoly {
@@ -38,7 +38,7 @@ impl CommonRandomPoly {
         rng: &mut R,
     ) -> Result<Self> {
         let ctx = par.context_at_level(level)?;
-        let poly = Poly::random(ctx, fhe_math::rq::Representation::Ntt, rng);
+        let poly = Poly::<Ntt>::random(ctx, rng);
         Ok(Self { poly })
     }
 }


### PR DESCRIPTION
Collapse Poly’s runtime state machine into type‑level representations. Today Representation, has_lazy_coefficients, and allow_variable_time_computations drive lots of branching and repeated checks across mod.rs and ops.rs. Split into Poly<PowerBasis>, Poly<Ntt>, Poly<NttShoup>, plus VarTime/ConstTime wrappers, and eliminate override_representation + many runtime panics.

