### PR TITLE
⚡ Optimize vector usage in Multiplicator setup

### DIFF
--- a/crates/fhe/src/bfv/ops/mul.rs
+++ b/crates/fhe/src/bfv/ops/mul.rs
@@ -107,7 +107,7 @@ impl Multiplicator {
         let n_moduli = (modulus_size + 60).div_ceil(62);
 
         let mut extended_basis = Vec::with_capacity(ctx.moduli().len() + n_moduli);
-        extended_basis.append(&mut ctx.moduli().to_vec());
+        extended_basis.extend_from_slice(ctx.moduli());
         let mut upper_bound = 1 << 62;
         while extended_basis.len() != ctx.moduli().len() + n_moduli {
             upper_bound = generate_prime(62, 2 * rk.ksk.par.degree() as u64, upper_bound).unwrap();


### PR DESCRIPTION
💡 **What:**
Replaced `extended_basis.append(&mut ctx.moduli().to_vec());` with `extended_basis.extend_from_slice(ctx.moduli());` in `crates/fhe/src/bfv/ops/mul.rs`.

🎯 **Why:**
To avoid allocating a temporary `Vec` when appending a slice to a `Vec`. `extend_from_slice` copies elements directly.

📊 **Measured Improvement:**
Measured using a custom criterion benchmark `Multiplicator::default`.
- Baseline: 17.04 ms
- Optimized: 17.43 ms
- Result: No statistically significant difference (within noise). The operation is dominated by prime generation and other setup steps. However, the change is a best-practice optimization that removes an unnecessary allocation.


---
*PR created automatically by Jules for task [1448834772391169533](https://jules.google.com/task/1448834772391169533) started by @tlepoint*