### PR TITLE
Update bytes 1.11.1 due to RUSTSEC-2026-0007

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,9 +141,9 @@ checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cast"


### PR DESCRIPTION
Update bytes 1.11.1 due to CVE-2026-25541 ( RUSTSEC-2026-0007 )

Reported by `cargo audit`:
```sh
Crate:     bytes
Version:   1.10.1
Title:     Integer overflow in `BytesMut::reserve`
Date:      2026-02-03
ID:        RUSTSEC-2026-0007
URL:       https://github.com/advisories/GHSA-434x-w66g-qw3r
Solution:  Upgrade to >=1.11.1
Dependency tree:
bytes 1.10.1
└── prost 0.14.3
    ├── prost-types 0.14.3
    │   └── prost-build 0.14.3
    │       ├── fhe-math 0.2.0
    │       │   └── fhe 0.2.0
    │       └── fhe 0.2.0
    ├── prost-build 0.14.3
    ├── fhe-math 0.2.0
    └── fhe 0.2.0
```
